### PR TITLE
Structured Logging

### DIFF
--- a/examples/tab_logger.go
+++ b/examples/tab_logger.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/go-logr/logr"
+)
+
+// TabLogger is a sample logr.Logger that logs to stderr.
+// It's terribly inefficient, and is *only* a basic example.
+type TabLogger struct{
+	name string
+	tags map[string]interface{}
+
+	writer *tabwriter.Writer
+}
+
+var _ logr.Logger = &TabLogger{}
+
+func (l *TabLogger) Info(msg string, kvs ...interface{}) {
+	fmt.Fprintf(l.writer, "%s\t%s\t", l.name, msg)
+	for k, v := range l.tags {
+		fmt.Fprintf(l.writer, "%s: %+v  ", k, v)
+	}
+	for i := 0; i < len(kvs); i += 2 {
+		fmt.Fprintf(l.writer, "%s: %+v  ", kvs[i], kvs[i+1])
+	}
+	fmt.Fprintf(l.writer, "\n")
+	l.writer.Flush()
+}
+
+func (_ *TabLogger) Enabled() bool {
+	return true
+}
+
+func (l *TabLogger) Error(err error, msg string, kvs ...interface{}) {
+	kvs = append(kvs, "error", err)
+	l.Info(msg, kvs...)
+}
+
+func (l *TabLogger) V(_ int) logr.InfoLogger {
+	return l
+}
+
+func (l *TabLogger) WithName(name string) logr.Logger {
+	return &TabLogger{
+		name: l.name+"."+name,
+		tags: l.tags,
+		writer: l.writer,
+	}
+}
+
+func (l *TabLogger) WithTags(kvs ...interface{}) logr.Logger {
+	newMap := make(map[string]interface{}, len(l.tags)+len(kvs)/2)
+	for k, v := range l.tags {
+		newMap[k] = v
+	}
+	for i := 0; i < len(kvs); i += 2 {
+		newMap[kvs[i].(string)] = kvs[i+1]
+	}
+	return &TabLogger{
+		name: l.name,
+		tags: newMap,
+		writer: l.writer,
+	}
+}
+
+func NewTabLogger() logr.Logger {
+	return &TabLogger{
+		writer: tabwriter.NewWriter(os.Stderr, 40, 8, 2, '\t', 0),
+	}
+}

--- a/examples/usage_example.go
+++ b/examples/usage_example.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// This application demonstrates the usage of logger.
+// It's a simple reconciliation loop that pretends to
+// receive notifications about updates from a some API
+// server, make some changes, and then submit updates of
+// its own.
+
+// This uses object-based logging.  It's also possible
+// (but a bit trickier) to use file-level "base" loggers.
+
+var objectMap = map[string]Object{
+	"obj1": Object{
+		Name: "obj1",
+		Kind: "one",
+		Details: 33,
+	},
+	"obj2": Object{
+		Name: "obj2",
+		Kind: "two",
+		Details: "hi",
+	},
+	"obj3": Object{
+		Name: "obj3",
+		Kind: "one",
+		Details: 1,
+	},
+}
+
+type Object struct {
+	Name string
+	Kind string
+	Details interface{}
+}
+
+type Client struct {
+	objects map[string]Object
+	log logr.Logger
+}
+
+func (c *Client) Get(key string) (Object, error) {
+	c.log.V(1).Info("fetching object", "key", key)
+	obj, ok := c.objects[key]
+	if !ok {
+		return Object{}, fmt.Errorf("no object %s exists", key)
+	}
+	c.log.V(1).Info("pretending to deserialize object", "key", key, "json", "[insert real json here]")
+	return obj, nil
+}
+
+func (c *Client) Save(obj Object) error {
+	c.log.V(1).Info("saving object", "key", obj.Name, "object", obj)
+	if rand.Intn(2) == 0 {
+		return fmt.Errorf("couldn't save to %s", obj.Name)
+	}
+	c.log.V(1).Info("pretending to post object", "key", obj.Name, "url", "https://fake.test")
+	return nil
+}
+
+func (c *Client) WatchNext() string {
+	time.Sleep(2*time.Second)
+
+	keyInd := rand.Intn(len(c.objects))
+
+	currInd := 0
+	for key := range c.objects {
+		if currInd == keyInd {
+			return key
+		}
+		currInd++
+	}
+
+	c.log.Info("watch ended")
+	return ""
+}
+
+type Controller struct {
+	log logr.Logger
+	expectedKind string
+	client *Client
+}
+
+func (c *Controller) Run() {
+	c.log.Info("starting reconciliation")
+
+	for key := c.client.WatchNext(); key != ""; key = c.client.WatchNext() {
+		// we can make more specific loggers if we always want to attach a particular tag
+		log := c.log.WithTags("key", key)
+
+		// fetch our object
+		obj, err := c.client.Get(key)
+		if err != nil {
+			log.Error(err, "unable to reconcile object")
+			continue
+		}
+
+		// make sure it's as expected
+		if obj.Kind != c.expectedKind {
+			log.Error(nil, "got object that wasn't expected kind", "actual-kind", obj.Kind, "object", obj)
+			continue
+		}
+
+		// always log the object with log messages
+		log = log.WithTags("object", obj)
+		log.V(1).Info("reconciling object for key")
+
+		// Do some complicated updates updates
+		obj.Details = obj.Details.(int) * 2
+
+		// actually save the updates
+		log.V(1).Info("updating object", "details", obj.Details)
+		if err := c.client.Save(obj); err != nil {
+			log.Error(err, "unable to reconcile object")
+		}
+	}
+
+	c.log.Info("stopping reconciliation")
+}
+
+func NewController(log logr.Logger, objectKind string) *Controller {
+	ctrlLogger := log.WithName("controller").WithName(objectKind)
+	client := &Client{
+		log: ctrlLogger.WithName("client"),
+		objects: objectMap,
+	}
+	return &Controller{
+		log: ctrlLogger,
+		expectedKind: objectKind,
+		client: client,
+	}
+}
+
+func main() {
+	// use a fake implementation just for demonstration purposes
+	log := NewTabLogger()
+
+	// update objects with the "one" kind
+	ctrl := NewController(log, "one")
+
+	ctrl.Run()
+}

--- a/logr.go
+++ b/logr.go
@@ -7,20 +7,86 @@
 //
 // This is a BETA grade API.  Until there is a significant 2nd implementation,
 // I don't really know how it will change.
+//
+// The logging specifically makes it non-trivial to use format strings, to encourage
+// attaching structured information instead of unstructured format strings.
+//
+// Usage
+//
+// Logging is done using a Logger.  Loggers can have name prefixes and tags attached,
+// so that all log messages logged with that Logger have some base context associated.
+//
+// For instance, suppose we're trying to reconcile the state of an object, and we want
+// to log that we've made some decision.
+//
+// With the traditional log package, we might write
+//  log.Printf(
+//      "decided to set field foo to value %q for object %s/%s",
+//       targetValue, object.Namespace, object.Name)
+//
+// With logr's structured logging, we'd write
+//  // elsewhere in the file, set up the logger to log with the prefix of "reconcilers",
+//  // and the tag target-type=Foo, for extra context.
+//  log := mainLogger.WithName("reconcilers").WithTag("target-type", "Foo")
+//
+//  // later on...
+//  log.Info("setting field foo on object", "value", targetValue, "object", object)
+//
+// Depending on our logging implementation, we could then make logging decisions based on field values
+// (like only logging such events for objects in a certain namespace), or copy the structured
+// information into a structured log store.
+//
+// For logging errors, Logger has a convinience method called Error.  Suppose we wanted to log an
+// error while reconciling.  With the traditional log package, we might write
+//   log.Errorf("unable to reconcile object %s/%s: %v", object.Namespace, object.Name, err)
+//
+// With logr, we'd instead write
+//   // assuming the above setup for log
+//   log.Error(err, "unable to reconcile object", "object", object)
+//
+// This is mostly identical to
+//   log.Info("unable to reconcile object", "error", err, "object", object)
+//
+// However, it's more convinient, and certain logging libraries may choose to attach additional
+// information (such as stack traces) on calls to Error, so it's preferred to use Error to log errors.
+//
+// Parts of a log line
+//
+// Each log message from a Logger has four types of context:
+// logger name, log verbosity, log message, and key-value pairs.
+//
+// The Logger name is constists of a series of name "segments" added by successive calls to WithName.
+// These name segments may contain anything but periods.  Exactly how these are represented in the
+// output is implementation-dependent.  A common format for implementations is to prefix log messages
+// with the name segments, separated by periods.
+//
+// Log verbosity represents how little a log matters.  Level zero, the default, matters most.
+// Increasing levels matter less and less.  Try to avoid lots of different verbosity levels,
+// and instead provide useful keys, logger names, and log messages instead for users to filter on
+// instead.
+//
+// The log message consists of a constant message attached to the the log line.  This
+// should generally be a simple description of what's occuring, and should never be a format string.
+//
+// Variable information can then be attached using key/value pairs.  Keys are arbitrary strings,
+// and values may be any Go object.
 package logr
 
-// TODO: consider structured logging, a la uber-go/zap
+// TODO: consider adding back in format strings if they're really needed
+// TODO: consider other bits of zap/zapcore functionality like ObjectMarshaller (for arbitrary objects)
 // TODO: consider other bits of glog functionality like Flush, InfoDepth, OutputStats
 
-// InfoLogger represents the ability to log non-error messages.
+// InfoLogger represents the ability to log non-error messages, at a particular verbosity.
 type InfoLogger interface {
-	// Info logs a non-error message.  This is behaviorally akin to fmt.Print.
-	Info(args ...interface{})
+	// Info logs a non-error message with the given key/value pairs as context.
+	//
+	// The msg argument should be used to add some constant description to
+	// the log line.  The key/value pairs can then be used to add additional
+	// variable information.  The key/value pairs should alternate string
+	// keys and arbitrary values.
+	Info(msg string, keysAndValues ...interface{})
 
-	// Infof logs a formatted non-error message.
-	Infof(format string, args ...interface{})
-
-	// Enabled test whether this InfoLogger is enabled.  For example,
+	// Enabled tests whether this InfoLogger is enabled.  For example,
 	// commandline flags might be used to set the logging verbosity and disable
 	// some info logs.
 	Enabled() bool
@@ -33,16 +99,28 @@ type Logger interface {
 	// example, logger.Info() produces the same result as logger.V(0).Info.
 	InfoLogger
 
-	// Error logs a error message.  This is behaviorally akin to fmt.Print.
-	Error(args ...interface{})
-
-	// Errorf logs a formatted error message.
-	Errorf(format string, args ...interface{})
+	// Error logs an error, with the given message and key/value pairs as context.
+	// It functions as a convinience wrapper around Info, and generally behaves
+	// equivalently to calling Info with the error attached as the "error" key,
+	// but this method should be preferred for logging errors  (see the package
+	// documentations for more information).
+	//
+	// The msg field should be used to add context to any underlying error,
+	// while the err field should be used to attach the actual error that
+	// triggered this log line, if present.
+	Error(err error, msg string, keysAndValues ...interface{})
 
 	// V returns an InfoLogger value for a specific verbosity level.  A higher
 	// verbosity level means a log message is less important.
 	V(level int) InfoLogger
 
-	// NewWithPrefix returns a Logger which prefixes all messages.
-	NewWithPrefix(prefix string) Logger
+	// WithTags adds some key-value pairs of context to a logger.
+	// See Info for documentation on how key/value pairs work.
+	WithTags(keysAndValues ...interface{}) Logger
+
+	// WithName adds a new suffix to the logger's name.
+	// Successive calls with WithName continue to append
+	// suffixes to the logger's name.  Name segments should
+	// not contain periods, but are otherwise freeform.
+	WithName(name string) Logger
 }

--- a/testing/null.go
+++ b/testing/null.go
@@ -1,6 +1,6 @@
 package testing
 
-import "github.com/thockin/logr"
+import "github.com/go-logr/logr"
 
 // NullLogger is a logr.Logger that does nothing.
 type NullLogger struct{}

--- a/testing/null.go
+++ b/testing/null.go
@@ -7,11 +7,7 @@ type NullLogger struct{}
 
 var _ logr.Logger = NullLogger{}
 
-func (_ NullLogger) Info(_ ...interface{}) {
-	// Do nothing.
-}
-
-func (_ NullLogger) Infof(_ string, _ ...interface{}) {
+func (_ NullLogger) Info(_ string, _ ...interface{}) {
 	// Do nothing.
 }
 
@@ -19,11 +15,7 @@ func (_ NullLogger) Enabled() bool {
 	return false
 }
 
-func (_ NullLogger) Error(_ ...interface{}) {
-	// Do nothing.
-}
-
-func (_ NullLogger) Errorf(_ string, _ ...interface{}) {
+func (_ NullLogger) Error(_ error, _ string, _ ...interface{}) {
 	// Do nothing.
 }
 
@@ -31,6 +23,10 @@ func (log NullLogger) V(_ int) logr.InfoLogger {
 	return log
 }
 
-func (log NullLogger) NewWithPrefix(_ string) logr.Logger {
+func (log NullLogger) WithName(_ string) logr.Logger {
+	return log
+}
+
+func (log NullLogger) WithTags(_ ...interface{}) logr.Logger {
 	return log
 }

--- a/testing/test.go
+++ b/testing/test.go
@@ -3,7 +3,7 @@ package testing
 import (
 	"testing"
 
-	"github.com/thockin/logr"
+	"github.com/go-logr/logr"
 )
 
 // TestLogger is a logr.Logger that prints through a testing.T object.

--- a/testing/test.go
+++ b/testing/test.go
@@ -14,11 +14,7 @@ type TestLogger struct {
 
 var _ logr.Logger = TestLogger{}
 
-func (_ TestLogger) Info(_ ...interface{}) {
-	// Do nothing.
-}
-
-func (_ TestLogger) Infof(_ string, _ ...interface{}) {
+func (_ TestLogger) Info(_ string, _ ...interface{}) {
 	// Do nothing.
 }
 
@@ -26,18 +22,18 @@ func (_ TestLogger) Enabled() bool {
 	return false
 }
 
-func (log TestLogger) Error(args ...interface{}) {
-	log.T.Log(args...)
-}
-
-func (log TestLogger) Errorf(format string, args ...interface{}) {
-	log.T.Logf(format, args...)
+func (log TestLogger) Error(err error, msg string, args ...interface{}) {
+	log.T.Logf("%s: %v -- %v", msg, err, args)
 }
 
 func (log TestLogger) V(v int) logr.InfoLogger {
 	return log
 }
 
-func (log TestLogger) NewWithPrefix(_ string) logr.Logger {
+func (log TestLogger) WithName(_ string) logr.Logger {
+	return log
+}
+
+func (log TestLogger) WithTags(_ ...interface{}) logr.Logger {
 	return log
 }


### PR DESCRIPTION
Switch the interfaces over to support/favor structured logging.
Format-string style logging is no longer supported by the interface.
Instead, callers should use tag-value pairs to introduce variable
information in a structured way.

The general pattern is based of go.uber.org/zap (specifically, the SugaredLogger),
but we keep some ofour own opinions (log levels go up, not down, numeric levels, etc),
and keep a limited interface.