### PR TITLE
Add link to logrus implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ There are implementations for the following logging libraries:
 - **go.uber.org/zap**: [zapr](https://github.com/go-logr/zapr)
 - **log** (the Go standard library logger):
   [stdr](https://github.com/go-logr/stdr)
+- **github.com/sirupsen/logrus**: [logrusr](https://github.com/bombsimon/logrusr)
 
 # FAQ
 


### PR DESCRIPTION
Not sure if you're open to PRs and/or custom implementations but I needed to fulfil a subset of this interface (to use with [`robfig/cron`](https://github.com/robfig/cron)) for `logrus` so I just implemented all of it.

I wouldn't say it's bullet proof but the code so far is well tested and working. Maybe this could help someone else using `logrus` and wants to use libraries requiring a `logr.Logger` implementation.

Oh and btw since you've stored the other implementations under the `go-logr` organization, do you want me to transfer this repository if you find the implementation good enough?