### PR TITLE
Get rid of InfoLogger, make V() additive

### DIFF
--- a/examples/tab_logger.go
+++ b/examples/tab_logger.go
@@ -17,8 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"text/tabwriter"
 
 	"github.com/go-logr/logr"
@@ -26,8 +26,8 @@ import (
 
 // TabLogger is a sample logr.Logger that logs to stderr.
 // It's terribly inefficient, and is *only* a basic example.
-type TabLogger struct{
-	name string
+type TabLogger struct {
+	name      string
 	keyValues map[string]interface{}
 
 	writer *tabwriter.Writer
@@ -56,15 +56,15 @@ func (l *TabLogger) Error(err error, msg string, kvs ...interface{}) {
 	l.Info(msg, kvs...)
 }
 
-func (l *TabLogger) V(_ int) logr.InfoLogger {
+func (l *TabLogger) V(_ int) logr.Logger {
 	return l
 }
 
 func (l *TabLogger) WithName(name string) logr.Logger {
 	return &TabLogger{
-		name: l.name+"."+name,
+		name:      l.name + "." + name,
 		keyValues: l.keyValues,
-		writer: l.writer,
+		writer:    l.writer,
 	}
 }
 
@@ -77,9 +77,9 @@ func (l *TabLogger) WithValues(kvs ...interface{}) logr.Logger {
 		newMap[kvs[i].(string)] = kvs[i+1]
 	}
 	return &TabLogger{
-		name: l.name,
+		name:      l.name,
 		keyValues: newMap,
-		writer: l.writer,
+		writer:    l.writer,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-logr/logr
+
+go 1.14

--- a/logr.go
+++ b/logr.go
@@ -128,15 +128,19 @@ limitations under the License.
 // above concepts, when neccessary (for example, in a pure-JSON output form, it
 // would be necessary to represent at least message and timestamp as ordinary
 // named values).
-//
 package logr
 
 // TODO: consider adding back in format strings if they're really needed
 // TODO: consider other bits of zap/zapcore functionality like ObjectMarshaller (for arbitrary objects)
 // TODO: consider other bits of glog functionality like Flush, InfoDepth, OutputStats
 
-// InfoLogger represents the ability to log non-error messages, at a particular verbosity.
-type InfoLogger interface {
+// Logger represents the ability to log messages, both errors and not.
+type Logger interface {
+	// Enabled tests whether this Logger is enabled.  For example, commandline
+	// flags might be used to set the logging verbosity and disable some info
+	// logs.
+	Enabled() bool
+
 	// Info logs a non-error message with the given key/value pairs as context.
 	//
 	// The msg argument should be used to add some constant description to
@@ -144,19 +148,6 @@ type InfoLogger interface {
 	// variable information.  The key/value pairs should alternate string
 	// keys and arbitrary values.
 	Info(msg string, keysAndValues ...interface{})
-
-	// Enabled tests whether this InfoLogger is enabled.  For example,
-	// commandline flags might be used to set the logging verbosity and disable
-	// some info logs.
-	Enabled() bool
-}
-
-// Logger represents the ability to log messages, both errors and not.
-type Logger interface {
-	// All Loggers implement InfoLogger.  Calling InfoLogger methods directly on
-	// a Logger value is equivalent to calling them on a V(0) InfoLogger.  For
-	// example, logger.Info() produces the same result as logger.V(0).Info.
-	InfoLogger
 
 	// Error logs an error, with the given message and key/value pairs as context.
 	// It functions similarly to calling Info with the "error" named value, but may
@@ -168,10 +159,11 @@ type Logger interface {
 	// triggered this log line, if present.
 	Error(err error, msg string, keysAndValues ...interface{})
 
-	// V returns an InfoLogger value for a specific verbosity level.  A higher
-	// verbosity level means a log message is less important.  It's illegal to
-	// pass a log level less than zero.
-	V(level int) InfoLogger
+	// V returns an Logger value for a specific verbosity level, relative to
+	// this Logger.  In other words, V values are additive.  V higher verbosity
+	// level means a log message is less important.  It's illegal to pass a log
+	// level less than zero.
+	V(level int) Logger
 
 	// WithValues adds some key-value pairs of context to a logger.
 	// See Info for documentation on how key/value pairs work.

--- a/testing/null.go
+++ b/testing/null.go
@@ -35,7 +35,7 @@ func (_ NullLogger) Error(_ error, _ string, _ ...interface{}) {
 	// Do nothing.
 }
 
-func (log NullLogger) V(_ int) logr.InfoLogger {
+func (log NullLogger) V(_ int) logr.Logger {
 	return log
 }
 

--- a/testing/test.go
+++ b/testing/test.go
@@ -42,7 +42,7 @@ func (log TestLogger) Error(err error, msg string, args ...interface{}) {
 	log.T.Logf("%s: %v -- %v", msg, err, args)
 }
 
-func (log TestLogger) V(v int) logr.InfoLogger {
+func (log TestLogger) V(v int) logr.Logger {
 	return log
 }
 


### PR DESCRIPTION
As per #6, simplify.

InfoLogger is no more.  There is only Logger.  This is a breaking
change.

Document V() as additive:  `l.V(1).V(2) is the same as `l.V(3)`

Fixes #6