### PR TITLE
Add link to genericr

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There are implementations for the following logging libraries:
 - **log** (the Go standard library logger):
   [stdr](https://github.com/go-logr/stdr)
 - **github.com/sirupsen/logrus**: [logrusr](https://github.com/bombsimon/logrusr)
+- **github.com/wojas/genericr**: [genericr](https://github.com/wojas/genericr) (makes it easy to implement your own backend)
 
 # FAQ
 


### PR DESCRIPTION
Add a link to genericr in the README.

Genericr makes it easy to implement your own log backend by implementing a single callback function.
