### PR TITLE
Add a Discard logger

### DIFF
--- a/discard.go
+++ b/discard.go
@@ -1,0 +1,35 @@
+package logr
+
+// Discard returns a valid Logger that discards all messages logged to it.
+// It can be used whenever the caller is not interested in the logs.
+func Discard() Logger {
+	return discardLogger{}
+}
+
+// discardLogger is a Logger that discards all messages.
+type discardLogger struct{}
+
+func (l discardLogger) Enabled() bool {
+	return false
+}
+
+func (l discardLogger) Info(msg string, keysAndValues ...interface{}) {
+}
+
+func (l discardLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+}
+
+func (l discardLogger) V(level int) Logger {
+	return l
+}
+
+func (l discardLogger) WithValues(keysAndValues ...interface{}) Logger {
+	return l
+}
+
+func (l discardLogger) WithName(name string) Logger {
+	return l
+}
+
+// Verify that it actually implements the interface
+var _ Logger = discardLogger{}

--- a/discard_test.go
+++ b/discard_test.go
@@ -1,0 +1,20 @@
+package logr
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDiscard(t *testing.T) {
+	l := Discard()
+	if _, ok := l.(discardLogger); !ok {
+		t.Error("did not return the expected underlying type")
+	}
+	// Verify that none of the methods panic, there is not more we can test.
+	l.WithName("discard").WithValues("z", 5).Info("Hello world")
+	l.Info("Hello world", "x", 1, "y", 2)
+	l.V(1).Error(errors.New("foo"), "a", 123)
+	if l.Enabled() {
+		t.Error("discard logger must always say it is disabled")
+	}
+}


### PR DESCRIPTION
**UPDATED**: Renamed the Null logger to Discard and removed the function to test for it.

Add a Discard logger exposed through a single `Discard()` function. 

The implementation was placed in the top level logr package to avoid an import loop if the top level packages wants to return a Discard logger.

The implementation was kept private to not pollute the package documentation with useless implementation details.

Usage:

```go
log := logr.Discard()
log.V(1).Info("Hello world") // discarded
```

Closes #26
