### PR TITLE
Effectively EOL testing.NullLogger

### DIFF
--- a/discard.go
+++ b/discard.go
@@ -19,33 +19,33 @@ package logr
 // Discard returns a valid Logger that discards all messages logged to it.
 // It can be used whenever the caller is not interested in the logs.
 func Discard() Logger {
-	return discardLogger{}
+	return DiscardLogger{}
 }
 
-// discardLogger is a Logger that discards all messages.
-type discardLogger struct{}
+// DiscardLogger is a Logger that discards all messages.
+type DiscardLogger struct{}
 
-func (l discardLogger) Enabled() bool {
+func (l DiscardLogger) Enabled() bool {
 	return false
 }
 
-func (l discardLogger) Info(msg string, keysAndValues ...interface{}) {
+func (l DiscardLogger) Info(msg string, keysAndValues ...interface{}) {
 }
 
-func (l discardLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (l DiscardLogger) Error(err error, msg string, keysAndValues ...interface{}) {
 }
 
-func (l discardLogger) V(level int) Logger {
+func (l DiscardLogger) V(level int) Logger {
 	return l
 }
 
-func (l discardLogger) WithValues(keysAndValues ...interface{}) Logger {
+func (l DiscardLogger) WithValues(keysAndValues ...interface{}) Logger {
 	return l
 }
 
-func (l discardLogger) WithName(name string) Logger {
+func (l DiscardLogger) WithName(name string) Logger {
 	return l
 }
 
 // Verify that it actually implements the interface
-var _ Logger = discardLogger{}
+var _ Logger = DiscardLogger{}

--- a/discard_test.go
+++ b/discard_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestDiscard(t *testing.T) {
 	l := Discard()
-	if _, ok := l.(discardLogger); !ok {
+	if _, ok := l.(DiscardLogger); !ok {
 		t.Error("did not return the expected underlying type")
 	}
 	// Verify that none of the methods panic, there is not more we can test.

--- a/logr.go
+++ b/logr.go
@@ -190,7 +190,9 @@ type Logger interface {
 // InfoLogger provides compatibility with code that relies on the v0.1.0
 // interface.
 //
-// Deprecated: use Logger instead. This will be removed in a future release.
+// Deprecated: InfoLogger is an artifact of early versions of this API.  New
+// users should never use it and existing users should use Logger instead. This
+// will be removed in a future release.
 type InfoLogger = Logger
 
 type contextKey struct{}
@@ -212,7 +214,7 @@ func FromContextOrDiscard(ctx context.Context) Logger {
 		return v
 	}
 
-	return discardLogger{}
+	return Discard()
 }
 
 // NewContext returns a new context derived from ctx that embeds the Logger.

--- a/logr_test.go
+++ b/logr_test.go
@@ -57,8 +57,8 @@ func TestContext(t *testing.T) {
 	}
 	if out := FromContextOrDiscard(ctx); out == nil {
 		t.Errorf("expected non-nil logger")
-	} else if _, ok := out.(discardLogger); !ok {
-		t.Errorf("expected a discardLogger, got %#v", out)
+	} else if _, ok := out.(DiscardLogger); !ok {
+		t.Errorf("expected a DiscardLogger, got %#v", out)
 	}
 
 	logger := &testLogger{}

--- a/testing/null.go
+++ b/testing/null.go
@@ -19,30 +19,8 @@ package testing
 import "github.com/go-logr/logr"
 
 // NullLogger is a logr.Logger that does nothing.
-type NullLogger struct{}
-
-var _ logr.Logger = NullLogger{}
-
-func (_ NullLogger) Info(_ string, _ ...interface{}) {
-	// Do nothing.
-}
-
-func (_ NullLogger) Enabled() bool {
-	return false
-}
-
-func (_ NullLogger) Error(_ error, _ string, _ ...interface{}) {
-	// Do nothing.
-}
-
-func (log NullLogger) V(_ int) logr.Logger {
-	return log
-}
-
-func (log NullLogger) WithName(_ string) logr.Logger {
-	return log
-}
-
-func (log NullLogger) WithValues(_ ...interface{}) logr.Logger {
-	return log
-}
+//
+// Deprecated: NullLogger is idenitcal to logr.DiscardLogger.  It is retained
+// for backwards compatibility, but new users should use logr.DiscardLogger
+// instead.
+type NullLogger = logr.DiscardLogger


### PR DESCRIPTION
It remains as a type, but is just an alias to DiscardLogger.

Fixes #33

I could be talked into simply deleting the type - thoughts?

@DirectXMan12 