### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ received:
 ```
     type appObject struct {
         // ... other fields ...
-        logger logr.Logr
+        logger logr.Logger
         // ... other fields ...
     }
 


### PR DESCRIPTION
I got confused by a typo in the README - hopefully this quick fix saves some time for future users.