### PR TITLE
support alternative way of skipping frames

### DIFF
--- a/testing/test.go
+++ b/testing/test.go
@@ -27,7 +27,8 @@ import (
 // Info logs are only enabled at V(0).
 func NewTestLogger(t *testing.T) logr.Logger {
 	fn := func(prefix, args string) {
+		t.Helper()
 		t.Logf("%s: %s", prefix, args)
 	}
-	return funcr.New(fn, funcr.Options{})
+	return funcr.New(fn, funcr.Options{Helper: t.Helper})
 }

--- a/testing/test_test.go
+++ b/testing/test_test.go
@@ -19,12 +19,27 @@ package testing
 import (
 	"fmt"
 	"testing"
+
+	"github.com/go-logr/logr"
 )
 
 func TestTestLogger(t *testing.T) {
-	logger := NewTestLogger(t)
-	logger.Info("info")
-	logger.V(0).Info("V(0).info")
-	logger.V(1).Info("v(1).info")
-	logger.Error(fmt.Errorf("error"), "error")
+	log := NewTestLogger(t)
+	log.Info("info")
+	log.V(0).Info("V(0).info")
+	log.V(1).Info("v(1).info")
+	log.Error(fmt.Errorf("error"), "error")
+	Helper(log, "hello world")
+}
+
+func Helper(log logr.Logger, msg string) {
+	helper, log := log.Helper()
+	helper()
+	helper2(log, msg)
+}
+
+func helper2(log logr.Logger, msg string) {
+	helper, log := log.Helper()
+	helper()
+	log.Info(msg)
 }


### PR DESCRIPTION
This is needed for log sinks where the underlying stack unwinding
doesn't support an explicit call depth, for example testing.T.Log.

One such log sink is currently pending in https://github.com/kubernetes/klog/pull/240.
It currently incorrectly logs logr.go as call site.
