### PR TITLE
embed funcr, custom With* function example

### DIFF
--- a/funcr/example_test.go
+++ b/funcr/example_test.go
@@ -18,6 +18,7 @@ package funcr_test
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
@@ -33,4 +34,82 @@ func ExampleUnderlier() {
 		fn("hello", "world")
 	}
 	// Output: hello world
+}
+
+// NewStdoutLogger returns a logr.Logger that prints to stdout.
+// It demonstrates how to implement a custom With* function which
+// controls whether INFO or ERROR are printed in front of the log
+// message.
+func NewStdoutLogger() logr.Logger {
+	l := &stdoutlogger{
+		Formatter: funcr.NewFormatter(funcr.Options{}),
+	}
+	return logr.New(l)
+}
+
+type stdoutlogger struct {
+	funcr.Formatter
+	logMsgType bool
+}
+
+func (l stdoutlogger) WithName(name string) logr.LogSink {
+	l.Formatter.AddName(name)
+	return &l
+}
+
+func (l stdoutlogger) WithValues(kvList ...interface{}) logr.LogSink {
+	l.Formatter.AddValues(kvList)
+	return &l
+}
+
+func (l stdoutlogger) WithCallDepth(depth int) logr.LogSink {
+	l.Formatter.AddCallDepth(depth)
+	return &l
+}
+
+func (l stdoutlogger) Info(level int, msg string, kvList ...interface{}) {
+	prefix, args := l.FormatInfo(level, msg, kvList)
+	l.write("INFO", prefix, args)
+}
+
+func (l stdoutlogger) Error(err error, msg string, kvList ...interface{}) {
+	prefix, args := l.FormatError(err, msg, kvList)
+	l.write("ERROR", prefix, args)
+}
+
+func (l stdoutlogger) write(msgType, prefix, args string) {
+	var parts []string
+	if l.logMsgType {
+		parts = append(parts, msgType)
+	}
+	if prefix != "" {
+		parts = append(parts, prefix)
+	}
+	parts = append(parts, args)
+	fmt.Println(strings.Join(parts, ": "))
+}
+
+// WithLogMsgType returns a copy of the logger with new settings for
+// logging the message type. It returns the original logger if the
+// underlying LogSink is not a stdoutlogger.
+func WithLogMsgType(log logr.Logger, logMsgType bool) logr.Logger {
+	if l, ok := log.GetSink().(*stdoutlogger); ok {
+		clone := *l
+		clone.logMsgType = logMsgType
+		log = log.WithSink(&clone)
+	}
+	return log
+}
+
+// Assert conformance to the interfaces.
+var _ logr.LogSink = &stdoutlogger{}
+var _ logr.CallDepthLogSink = &stdoutlogger{}
+
+func ExampleFormatter() {
+	l := NewStdoutLogger()
+	l.Info("no message type")
+	WithLogMsgType(l, true).Info("with message type")
+	// Output:
+	// "level"=0 "msg"="no message type"
+	// INFO: "level"=0 "msg"="with message type"
 }

--- a/testing/test_test.go
+++ b/testing/test_test.go
@@ -23,12 +23,13 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func TestTestLogger(t *testing.T) {
+func TestLogger(t *testing.T) {
 	log := NewTestLogger(t)
 	log.Info("info")
 	log.V(0).Info("V(0).info")
 	log.V(1).Info("v(1).info")
 	log.Error(fmt.Errorf("error"), "error")
+	log.WithName("testing").Info("with prefix")
 	Helper(log, "hello world")
 }
 


### PR DESCRIPTION
This allows custom loggers to provide their own additional methods
while using most of the implementation from funcr.
    
That funcr had to be extended to support the helper concept in
testing.T didn't feel right because fnlogger then always implemented
the CallStackHelperLogSink interface even when the helper was
nil. This gets fixed by moving the implementation of that into the
testing logger, using the new embedding mechanism of funcr.
    
As a drive-by fix, the testing logger no longer prints a redundant ":"
when the prefix is empty.
    
The logr package describes how to implement a custom With* function. A
runable example for that gets added in funcr/example_test.go.
