### PR TITLE
fix incremental WithCallDepth

### DIFF
--- a/discard.go
+++ b/discard.go
@@ -22,7 +22,7 @@ package logr
 func Discard() Logger {
 	return Logger{
 		level: 0,
-		Sink:  discardLogSink{},
+		sink:  discardLogSink{},
 	}
 }
 

--- a/discard_test.go
+++ b/discard_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestDiscard(t *testing.T) {
 	l := Discard()
-	if _, ok := l.Sink.(discardLogSink); !ok {
+	if _, ok := l.GetSink().(discardLogSink); !ok {
 		t.Error("did not return the expected underlying type")
 	}
 	// Verify that none of the methods panic, there is not more we can test.

--- a/funcr/example_test.go
+++ b/funcr/example_test.go
@@ -28,7 +28,7 @@ func ExampleUnderlier() {
 		fmt.Println(prefix, args)
 	}, funcr.Options{})
 
-	if underlier, ok := log.Sink.(funcr.Underlier); ok {
+	if underlier, ok := log.GetSink().(funcr.Underlier); ok {
 		fn := underlier.GetUnderlying()
 		fn("hello", "world")
 	}


### PR DESCRIPTION
When WithCallDepth stored the new sink, it didn't update the cached
withCallDepth implementation. When that then was called again by
another WithCallDepth, the previously incremented call depth was
overwritten.