### PR TITLE
Remove caching of optional interfaces

### DIFF
--- a/logr_test.go
+++ b/logr_test.go
@@ -111,8 +111,8 @@ func TestNew(t *testing.T) {
 	if calledInit != 1 {
 		t.Errorf("expected sink.Init() to be called once, got %d", calledInit)
 	}
-	if logger.withCallDepth != nil {
-		t.Errorf("expected withCallDepth to be nil, got %v", logger.withCallDepth)
+	if _, ok := logger.sink.(CallDepthLogSink); ok {
+		t.Errorf("expected conversion to CallDepthLogSink to fail")
 	}
 }
 
@@ -120,8 +120,8 @@ func TestNewCachesCallDepthInterface(t *testing.T) {
 	sink := &testCallDepthLogSink{}
 	logger := New(sink)
 
-	if logger.withCallDepth == nil {
-		t.Errorf("expected withCallDepth to be set")
+	if _, ok := logger.sink.(CallDepthLogSink); !ok {
+		t.Errorf("expected conversion to CallDepthLogSink to succeed")
 	}
 }
 


### PR DESCRIPTION
Caching these interfaces makes everything more complicated for very VERY little gain.  Let's just do the interface assertions when we need them.  The cost of this is dominated by the actual act of formatting and logging.

cc @pohly 