### PR TITLE
testing: enable configuration of log level and time stamps

### DIFF
--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -67,7 +67,7 @@ type Options struct {
 	// This has some overhead, so some users might not want it.
 	LogCaller MessageClass
 
-	// LogTimestamps tells funcr to add a "ts" key to log lines.  This has some
+	// LogTimestamp tells funcr to add a "ts" key to log lines.  This has some
 	// overhead, so some users might not want it.
 	LogTimestamp bool
 

--- a/testing/test.go
+++ b/testing/test.go
@@ -33,6 +33,31 @@ func NewTestLogger(t *testing.T) logr.Logger {
 	return logr.New(l)
 }
 
+// Options carries parameters which influence the way logs are generated.
+type Options struct {
+	// LogTimestamp tells the logger to add a "ts" key to log
+	// lines. This has some overhead, so some users might not want
+	// it.
+	LogTimestamp bool
+
+	// Verbosity tells the logger which V logs to be write.
+	// Higher values enable more logs.
+	Verbosity int
+}
+
+// NewTestLoggerWithOptions returns a logr.Logger that prints through a testing.T object.
+// In contrast to the simpler NewTestLogger, output formatting can be configured.
+func NewTestLoggerWithOptions(t *testing.T, opts Options) logr.Logger {
+	l := &testlogger{
+		Formatter: funcr.NewFormatter(funcr.Options{
+			LogTimestamp: opts.LogTimestamp,
+			Verbosity:    opts.Verbosity,
+		}),
+		t: t,
+	}
+	return logr.New(l)
+}
+
 // Underlier exposes access to the underlying testing.T instance. Since
 // callers only have a logr.Logger, they have to know which
 // implementation is in use, so this interface is less of an

--- a/testing/test_test.go
+++ b/testing/test_test.go
@@ -31,6 +31,12 @@ func TestLogger(t *testing.T) {
 	log.Error(fmt.Errorf("error"), "error")
 	log.WithName("testing").Info("with prefix")
 	Helper(log, "hello world")
+
+	log = NewTestLoggerWithOptions(t, Options{
+		LogTimestamp: true,
+		Verbosity:    1,
+	})
+	log.V(1).Info("v(1).info with options")
 }
 
 func Helper(log logr.Logger, msg string) {


### PR DESCRIPTION
Both may or may not be useful. Now the user can decide.