### PR TITLE
use golangci-lint-action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,6 +22,7 @@ jobs:
                 -v
                 --max-same-issues 10
                 --disable-all
+                --exclude-use-default=false
                 -E asciicheck
                 -E deadcode
                 -E errcheck

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,32 +6,36 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Lint
-        run: |
-          docker run --rm -v `pwd`:/go/src/prj -w /go/src/prj \
-            golangci/golangci-lint golangci-lint run \
-                -v \
-                --max-same-issues 10 \
-                --disable-all \
-                -E asciicheck \
-                -E deadcode \
-                -E errcheck \
-                -E forcetypeassert \
-                -E gocritic \
-                -E gofmt \
-                -E goimports \
-                -E gosimple \
-                -E govet \
-                -E ineffassign \
-                -E misspell \
-                -E revive \
-                -E staticcheck \
-                -E structcheck \
-                -E typecheck \
-                -E unused \
-                -E varcheck
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
 
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # golangci-lint command line arguments.
+          args:
+                -v
+                --max-same-issues 10
+                --disable-all
+                -E asciicheck
+                -E deadcode
+                -E errcheck
+                -E forcetypeassert
+                -E gocritic
+                -E gofmt
+                -E goimports
+                -E gosimple
+                -E govet
+                -E ineffassign
+                -E misspell
+                -E revive
+                -E staticcheck
+                -E structcheck
+                -E typecheck
+                -E unused
+                -E varcheck

--- a/funcr/example/main.go
+++ b/funcr/example/main.go
@@ -23,15 +23,15 @@ import (
 	"github.com/go-logr/logr/funcr"
 )
 
-type E struct {
+type e struct {
 	str string
 }
 
-func (e E) Error() string {
+func (e e) Error() string {
 	return e.str
 }
 
-func Helper(log logr.Logger, msg string) {
+func helper(log logr.Logger, msg string) {
 	helper2(log, msg)
 }
 
@@ -54,6 +54,6 @@ func example(log logr.Logger) {
 	log.V(1).Info("you should see this")
 	log.V(1).V(1).Info("you should NOT see this")
 	log.Error(nil, "uh oh", "trouble", true, "reasons", []float64{0.1, 0.11, 3.14})
-	log.Error(E{"an error occurred"}, "goodbye", "code", -1)
-	Helper(log, "thru a helper")
+	log.Error(e{"an error occurred"}, "goodbye", "code", -1)
+	helper(log, "thru a helper")
 }

--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -80,9 +80,13 @@ type Options struct {
 type MessageClass int
 
 const (
+	// None ignores all message classes.
 	None MessageClass = iota
+	// All considers all message classes.
 	All
+	// Info only considers info messages.
 	Info
+	// Error only considers error messages.
 	Error
 )
 
@@ -327,11 +331,12 @@ func (f Formatter) caller() callerID {
 	return callerID{filepath.Base(file), line}
 }
 
-// Note that this receiver is a pointer, so depth can be saved.
+// Init uses a pointer receiver, so depth can be saved.
 func (f *Formatter) Init(info logr.RuntimeInfo) {
 	f.depth += info.CallDepth
 }
 
+// Enabled checks whether an info message at the given level should be logged.
 func (f Formatter) Enabled(level int) bool {
 	return level <= f.verbosity
 }
@@ -352,7 +357,7 @@ func (f Formatter) FormatInfo(level int, msg string, kvList []interface{}) (pref
 	return f.prefix, flatten(args...)
 }
 
-// FormatInfo flattens an Error log message into strings.
+// FormatError flattens an Error log message into strings.
 // The prefix will be empty when no names were set.
 func (f Formatter) FormatError(err error, msg string, kvList []interface{}) (prefix, argsStr string) {
 	args := make([]interface{}, 0, 64) // using a constant here impacts perf
@@ -383,12 +388,15 @@ func (f *Formatter) AddName(name string) {
 	f.prefix += name
 }
 
+// AddValues appends the specified values.
 func (f *Formatter) AddValues(kvList []interface{}) {
 	// Three slice args forces a copy.
 	n := len(f.values)
 	f.values = append(f.values[:n:n], kvList...)
 }
 
+// AddCallDepth increases the number of stack frames that need to be
+// skipped.
 func (f *Formatter) AddCallDepth(depth int) {
 	f.depth += depth
 }

--- a/logr.go
+++ b/logr.go
@@ -339,7 +339,7 @@ func (l Logger) WithCallDepth(depth int) Logger {
 // it supports a WithCallStackHelper() method, that will be also
 // called. If the implementation does not support either of these, the
 // original Logger will be returned.
-func (l Logger) Helper() (func(), Logger) {
+func (l Logger) WithCallStackHelper() (func(), Logger) {
 	var helper func()
 	if withCallDepth, ok := l.sink.(CallDepthLogSink); ok {
 		l.setSink(withCallDepth.WithCallDepth(1))

--- a/testing/test_test.go
+++ b/testing/test_test.go
@@ -40,13 +40,13 @@ func TestLogger(t *testing.T) {
 }
 
 func Helper(log logr.Logger, msg string) {
-	helper, log := log.Helper()
+	helper, log := log.WithCallStackHelper()
 	helper()
 	helper2(log, msg)
 }
 
 func helper2(log logr.Logger, msg string) {
-	helper, log := log.Helper()
+	helper, log := log.WithCallStackHelper()
 	helper()
 	log.Info(msg)
 }


### PR DESCRIPTION
The integration with GitHub is better. It uses caching and posts
errors as annotations to the PR. This is easier to use than having to
dig into the log to find errors.

Fixes #82