### PR TITLE
remove some unsupported markup

### DIFF
--- a/logr.go
+++ b/logr.go
@@ -21,8 +21,7 @@ limitations under the License.
 // to back that API.  Packages in the Go ecosystem can depend on this package,
 // while callers can implement logging with whatever backend is appropriate.
 //
-// Usage
-// -----
+// # Usage
 //
 // Logging is done using a Logger instance.  Logger is a concrete type with
 // methods, which defers the actual logging to a LogSink interface.  The main
@@ -46,8 +45,7 @@ limitations under the License.
 // LogSink implementations can choose to do things like attach additional
 // information (such as stack traces) on calls to Error().
 //
-// Verbosity
-// ---------
+// # Verbosity
 //
 // Often we want to log information only when the application in "verbose
 // mode".  To write log-lines that are more verbose, Logger has a V() method.
@@ -64,8 +62,7 @@ limitations under the License.
 // We can write:
 //   logger.V(2).Info("an unusual thing happened")
 //
-// Logger Names
-// ------------
+// # Logger Names
 //
 // Logger instances can have name strings so that all messages logged through
 // that instance have additional context.  For example, you might want to add
@@ -82,8 +79,7 @@ limitations under the License.
 // joining operation (e.g. whitespace, commas, periods, slashes, brackets,
 // quotes, etc).
 //
-// Saved Values
-// ------------
+// # Saved Values
 //
 // Logger instances can store any number of key/value pairs, which will be
 // logged alongside all messages logged through that instance.  For example,
@@ -101,8 +97,7 @@ limitations under the License.
 //   // later on...
 //   obj.logger.Info("setting foo", "value", targetValue)
 //
-// Best Practices
-// --------------
+// # Best Practices
 //
 // Logger has very few hard rules, with the goal that LogSink implementations
 // might have a lot of freedom to differentiate.  There are, however, some
@@ -117,8 +112,7 @@ limitations under the License.
 // may be any Go value, but how the value is formatted is determined by the
 // LogSink implementation.
 //
-// Key Naming Conventions
-// ----------------------
+// # Key Naming Conventions
 //
 // Keys are not strictly required to conform to any specification or regex, but
 // it is recommended that they:
@@ -136,22 +130,21 @@ limitations under the License.
 // generally best to avoid using the following keys, as they're frequently used
 // by implementations:
 //
-//   * `"caller"`: the calling information (file/line) of a particular log line.
-//   * `"error"`: the underlying error value in the `Error` method.
-//   * `"level"`: the log level.
-//   * `"logger"`: the name of the associated logger.
-//   * `"msg"`: the log message.
-//   * `"stacktrace"`: the stack trace associated with a particular log line or
-//                     error (often from the `Error` message).
-//   * `"ts"`: the timestamp for a log line.
+//   * "caller": the calling information (file/line) of a particular log line.
+//   * "error": the underlying error value in the `Error` method.
+//   * "level": the log level.
+//   * "logger": the name of the associated logger.
+//   * "msg": the log message.
+//   * "stacktrace": the stack trace associated with a particular log line or
+//                   error (often from the `Error` message).
+//   * "ts": the timestamp for a log line.
 //
 // Implementations are encouraged to make use of these keys to represent the
 // above concepts, when necessary (for example, in a pure-JSON output form, it
 // would be necessary to represent at least message and timestamp as ordinary
 // named values).
 //
-// Break Glass
-// -----------
+// # Break Glass
 //
 // Implementations may choose to give callers access to the underlying
 // logging implementation.  The recommended pattern for this is:


### PR DESCRIPTION
Sections and verbatim text are not supported by godoc comments which
made the resulting page on pkg.go.dev less readable.

Fixes: #79