### PR TITLE
handle typed nil on field

### DIFF
--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -287,6 +287,9 @@ func prettyWithFlags(value interface{}, flags uint32) string {
 		buf.WriteRune('}')
 		return buf.String()
 	case reflect.Ptr, reflect.Interface:
+		if v.IsNil() {
+			return "null"
+		}
 		return pretty(v.Elem().Interface())
 	}
 	return fmt.Sprintf(`"<unhandled-%s>"`, t.Kind().String())

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -95,6 +95,15 @@ func TestPretty(t *testing.T) {
 			{"nine", "three"},
 			{"seven", "six"},
 		},
+		struct {
+			A *int
+			B *int
+			C interface{}
+			D interface{}
+		}{
+			B: ptrint(1),
+			D: interface{}(2),
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
it raised panic. I fixed it.

so, I want to add tests about `Y, Z []int` for `nil` and `([]int)(nil)`, but its not compatible to `json.Marshal`.
