### PR TITLE
Update zerologr url

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ There are implementations for the following logging libraries:
 - **github.com/sirupsen/logrus**: [logrusr](https://github.com/bombsimon/logrusr)
 - **github.com/wojas/genericr**: [genericr](https://github.com/wojas/genericr) (makes it easy to implement your own backend)
 - **logfmt** (Heroku style [logging](https://www.brandur.org/logfmt)): [logfmtr](https://github.com/iand/logfmtr)
-- **zerolog**: [zerologr](https://github.com/hn8/zerologr)
+- **github.com/rs/zerolog**: [zerologr](https://github.com/screenleap/zerologr)
 
 ## FAQ
 


### PR DESCRIPTION
Transferred from hn8 to screenleap. Wait for
https://github.com/go-logr/logr/issues/59