### PR TITLE
support flushing of buffered messages

### DIFF
--- a/logr.go
+++ b/logr.go
@@ -429,6 +429,15 @@ type LogSink interface {
 	WithName(name string) LogSink
 }
 
+// FlushLogSink is an optional interface that LogSinks can implement when they
+// support buffering of log messages.
+type FlushLogSink interface {
+	// Flush should be called by a program shortly before terminating and,
+	// if the underlying LogSink doesn't support periodic flushing by
+	// itself, also at regular intervals.
+	Flush()
+}
+
 // CallDepthLogSink represents a Logger that knows how to climb the call stack
 // to identify the original call site and can offset the depth by a specified
 // number of frames.  This is useful for users who have helper functions


### PR DESCRIPTION
Buffering can increase performance because the log stream can be processed in
larger chunks instead of line-by-line. The drawback is that all buffered
messages must be explicitly flushed at least at program exit because Go doesn't
support "atexit" hooks.
