### PR TITLE
funcr: Add JSON mode

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -24,9 +24,6 @@ import (
 	"github.com/go-logr/logr/funcr"
 )
 
-func noop(prefix, args string) {
-}
-
 //go:noinline
 func doInfoOneArg(b *testing.B, log logr.Logger) {
 	for i := 0; i < b.N; i++ {
@@ -95,27 +92,27 @@ func doWithCallDepth(b *testing.B, log logr.Logger) {
 	}
 }
 
-func BenchmarkDiscardInfoOneArg(b *testing.B) {
+func BenchmarkDiscardLogInfoOneArg(b *testing.B) {
 	var log logr.Logger = logr.Discard()
 	doInfoOneArg(b, log)
 }
 
-func BenchmarkDiscardInfoSeveralArgs(b *testing.B) {
+func BenchmarkDiscardLogInfoSeveralArgs(b *testing.B) {
 	var log logr.Logger = logr.Discard()
 	doInfoSeveralArgs(b, log)
 }
 
-func BenchmarkDiscardV0Info(b *testing.B) {
+func BenchmarkDiscardLogV0Info(b *testing.B) {
 	var log logr.Logger = logr.Discard()
 	doV0Info(b, log)
 }
 
-func BenchmarkDiscardV9Info(b *testing.B) {
+func BenchmarkDiscardLogV9Info(b *testing.B) {
 	var log logr.Logger = logr.Discard()
 	doV9Info(b, log)
 }
 
-func BenchmarkDiscardError(b *testing.B) {
+func BenchmarkDiscardLogError(b *testing.B) {
 	var log logr.Logger = logr.Discard()
 	doError(b, log)
 }
@@ -130,42 +127,70 @@ func BenchmarkDiscardWithName(b *testing.B) {
 	doWithName(b, log)
 }
 
-func BenchmarkFuncrInfoOneArg(b *testing.B) {
-	var log logr.Logger = funcr.New(noop, funcr.Options{})
+func noopKV(prefix, args string) {}
+func noopJSON(obj string)        {}
+
+func BenchmarkFuncrLogInfoOneArg(b *testing.B) {
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
 	doInfoOneArg(b, log)
 }
 
-func BenchmarkFuncrInfoSeveralArgs(b *testing.B) {
-	var log logr.Logger = funcr.New(noop, funcr.Options{})
+func BenchmarkFuncrJSONLogInfoOneArg(b *testing.B) {
+	var log logr.Logger = funcr.NewJSON(noopJSON, funcr.Options{})
+	doInfoOneArg(b, log)
+}
+
+func BenchmarkFuncrLogInfoSeveralArgs(b *testing.B) {
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
 	doInfoSeveralArgs(b, log)
 }
 
-func BenchmarkFuncrV0Info(b *testing.B) {
-	var log logr.Logger = funcr.New(noop, funcr.Options{})
+func BenchmarkFuncrJSONLogInfoSeveralArgs(b *testing.B) {
+	var log logr.Logger = funcr.NewJSON(noopJSON, funcr.Options{})
+	doInfoSeveralArgs(b, log)
+}
+
+func BenchmarkFuncrLogV0Info(b *testing.B) {
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
 	doV0Info(b, log)
 }
 
-func BenchmarkFuncrV9Info(b *testing.B) {
-	var log logr.Logger = funcr.New(noop, funcr.Options{})
+func BenchmarkFuncrJSONLogV0Info(b *testing.B) {
+	var log logr.Logger = funcr.NewJSON(noopJSON, funcr.Options{})
+	doV0Info(b, log)
+}
+
+func BenchmarkFuncrLogV9Info(b *testing.B) {
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
 	doV9Info(b, log)
 }
 
-func BenchmarkFuncrError(b *testing.B) {
-	var log logr.Logger = funcr.New(noop, funcr.Options{})
+func BenchmarkFuncrJSONLogV9Info(b *testing.B) {
+	var log logr.Logger = funcr.NewJSON(noopJSON, funcr.Options{})
+	doV9Info(b, log)
+}
+
+func BenchmarkFuncrLogError(b *testing.B) {
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
+	doError(b, log)
+}
+
+func BenchmarkFuncrJSONLogError(b *testing.B) {
+	var log logr.Logger = funcr.NewJSON(noopJSON, funcr.Options{})
 	doError(b, log)
 }
 
 func BenchmarkFuncrWithValues(b *testing.B) {
-	var log logr.Logger = funcr.New(noop, funcr.Options{})
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
 	doWithValues(b, log)
 }
 
 func BenchmarkFuncrWithName(b *testing.B) {
-	var log logr.Logger = funcr.New(noop, funcr.Options{})
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
 	doWithName(b, log)
 }
 
 func BenchmarkFuncrWithCallDepth(b *testing.B) {
-	var log logr.Logger = funcr.New(noop, funcr.Options{})
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
 	doWithCallDepth(b, log)
 }

--- a/funcr/example_test.go
+++ b/funcr/example_test.go
@@ -24,6 +24,28 @@ import (
 	"github.com/go-logr/logr/funcr"
 )
 
+func ExampleNew() {
+	var log logr.Logger = funcr.New(func(prefix, args string) {
+		fmt.Println(prefix, args)
+	}, funcr.Options{})
+
+	log = log.WithName("MyLogger")
+	log = log.WithValues("savedKey", "savedValue")
+	log.Info("the message", "key", "value")
+	// Output: MyLogger "level"=0 "msg"="the message" "savedKey"="savedValue" "key"="value"
+}
+
+func ExampleNewJSON() {
+	var log logr.Logger = funcr.NewJSON(func(obj string) {
+		fmt.Println(obj)
+	}, funcr.Options{})
+
+	log = log.WithName("MyLogger")
+	log = log.WithValues("savedKey", "savedValue")
+	log.Info("the message", "key", "value")
+	// Output: {"logger":"MyLogger","level":0,"msg":"the message","savedKey":"savedValue","key":"value"}
+}
+
 func ExampleUnderlier() {
 	var log logr.Logger = funcr.New(func(prefix, args string) {
 		fmt.Println(prefix, args)

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -193,37 +193,48 @@ func makeKV(args ...interface{}) []interface{} {
 
 func TestFlatten(t *testing.T) {
 	testCases := []struct {
-		name   string
-		kv     []interface{}
-		expect string
+		name       string
+		kv         []interface{}
+		expectKV   string
+		expectJSON string
 	}{{
-		name:   "nil",
-		kv:     nil,
-		expect: "",
+		name:       "nil",
+		kv:         nil,
+		expectKV:   "",
+		expectJSON: "{}",
 	}, {
-		name:   "empty",
-		kv:     []interface{}{},
-		expect: "",
+		name:       "empty",
+		kv:         []interface{}{},
+		expectKV:   "",
+		expectJSON: "{}",
 	}, {
-		name:   "primitives",
-		kv:     makeKV("int", 1, "str", "ABC", "bool", true),
-		expect: `"int"=1 "str"="ABC" "bool"=true`,
+		name:       "primitives",
+		kv:         makeKV("int", 1, "str", "ABC", "bool", true),
+		expectKV:   `"int"=1 "str"="ABC" "bool"=true`,
+		expectJSON: `{"int":1,"str":"ABC","bool":true}`,
 	}, {
-		name:   "missing value",
-		kv:     makeKV("key"),
-		expect: `"key"="<no-value>"`,
+		name:       "missing value",
+		kv:         makeKV("key"),
+		expectKV:   `"key"="<no-value>"`,
+		expectJSON: `{"key":"<no-value>"}`,
 	}, {
-		name:   "non-string key",
-		kv:     makeKV(123, "val"),
-		expect: `"<non-string-key-0>"="val"`,
+		name:       "non-string key",
+		kv:         makeKV(123, "val"),
+		expectKV:   `"<non-string-key-0>"="val"`,
+		expectJSON: `{"<non-string-key-0>":"val"}`,
 	}}
 
-	f := NewFormatter(Options{})
+	fKV := NewFormatter(Options{})
+	fJSON := NewFormatterJSON(Options{})
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := f.flatten(tc.kv...)
-			if r != tc.expect {
-				t.Errorf("expected %q, got %q", tc.expect, r)
+			r := fKV.flatten(tc.kv...)
+			if r != tc.expectKV {
+				t.Errorf("expected %q, got %q", tc.expectKV, r)
+			}
+			r = fJSON.flatten(tc.kv...)
+			if r != tc.expectJSON {
+				t.Errorf("expected %q, got %q", tc.expectJSON, r)
 			}
 		})
 	}
@@ -231,7 +242,7 @@ func TestFlatten(t *testing.T) {
 
 func TestEnabled(t *testing.T) {
 	t.Run("default V", func(t *testing.T) {
-		log := newSink(func(prefix, args string) {}, Options{})
+		log := newSink(func(prefix, args string) {}, NewFormatter(Options{}))
 		if !log.Enabled(0) {
 			t.Errorf("expected true")
 		}
@@ -240,7 +251,7 @@ func TestEnabled(t *testing.T) {
 		}
 	})
 	t.Run("V=9", func(t *testing.T) {
-		log := newSink(func(prefix, args string) {}, Options{Verbosity: 9})
+		log := newSink(func(prefix, args string) {}, NewFormatter(Options{Verbosity: 9}))
 		if !log.Enabled(8) {
 			t.Errorf("expected true")
 		}
@@ -279,7 +290,7 @@ func TestInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cap := &capture{}
-			sink := newSink(cap.Func, Options{})
+			sink := newSink(cap.Func, NewFormatter(Options{}))
 			sink.Info(0, "msg", tc.args...)
 			if cap.log != tc.expect {
 				t.Errorf("\nexpected %q\n     got %q", tc.expect, cap.log)
@@ -291,7 +302,7 @@ func TestInfo(t *testing.T) {
 func TestInfoWithCaller(t *testing.T) {
 	t.Run("LogCaller=All", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: All})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All}))
 		sink.Info(0, "msg")
 		_, file, line, _ := runtime.Caller(0)
 		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "level"=0 "msg"="msg"`, filepath.Base(file), line-1)
@@ -301,7 +312,7 @@ func TestInfoWithCaller(t *testing.T) {
 	})
 	t.Run("LogCaller=Info", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: Info})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: Info}))
 		sink.Info(0, "msg")
 		_, file, line, _ := runtime.Caller(0)
 		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "level"=0 "msg"="msg"`, filepath.Base(file), line-1)
@@ -311,7 +322,7 @@ func TestInfoWithCaller(t *testing.T) {
 	})
 	t.Run("LogCaller=Error", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: Error})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: Error}))
 		sink.Info(0, "msg")
 		expect := ` "level"=0 "msg"="msg"`
 		if cap.log != expect {
@@ -320,7 +331,7 @@ func TestInfoWithCaller(t *testing.T) {
 	})
 	t.Run("LogCaller=None", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: None})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: None}))
 		sink.Info(0, "msg")
 		expect := ` "level"=0 "msg"="msg"`
 		if cap.log != expect {
@@ -347,7 +358,7 @@ func TestError(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cap := &capture{}
-			sink := newSink(cap.Func, Options{})
+			sink := newSink(cap.Func, NewFormatter(Options{}))
 			sink.Error(fmt.Errorf("err"), "msg", tc.args...)
 			if cap.log != tc.expect {
 				t.Errorf("\nexpected %q\n     got %q", tc.expect, cap.log)
@@ -359,7 +370,7 @@ func TestError(t *testing.T) {
 func TestErrorWithCaller(t *testing.T) {
 	t.Run("LogCaller=All", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: All})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All}))
 		sink.Error(fmt.Errorf("err"), "msg")
 		_, file, line, _ := runtime.Caller(0)
 		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "msg"="msg" "error"="err"`, filepath.Base(file), line-1)
@@ -369,7 +380,7 @@ func TestErrorWithCaller(t *testing.T) {
 	})
 	t.Run("LogCaller=Error", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: Error})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: Error}))
 		sink.Error(fmt.Errorf("err"), "msg")
 		_, file, line, _ := runtime.Caller(0)
 		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "msg"="msg" "error"="err"`, filepath.Base(file), line-1)
@@ -379,7 +390,7 @@ func TestErrorWithCaller(t *testing.T) {
 	})
 	t.Run("LogCaller=Info", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: Info})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: Info}))
 		sink.Error(fmt.Errorf("err"), "msg")
 		expect := ` "msg"="msg" "error"="err"`
 		if cap.log != expect {
@@ -388,7 +399,7 @@ func TestErrorWithCaller(t *testing.T) {
 	})
 	t.Run("LogCaller=None", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: None})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: None}))
 		sink.Error(fmt.Errorf("err"), "msg")
 		expect := ` "msg"="msg" "error"="err"`
 		if cap.log != expect {
@@ -418,7 +429,7 @@ func TestInfoWithName(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cap := &capture{}
-			sink := newSink(cap.Func, Options{})
+			sink := newSink(cap.Func, NewFormatter(Options{}))
 			for _, n := range tc.names {
 				sink = sink.WithName(n)
 			}
@@ -451,7 +462,7 @@ func TestErrorWithName(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cap := &capture{}
-			sink := newSink(cap.Func, Options{})
+			sink := newSink(cap.Func, NewFormatter(Options{}))
 			for _, n := range tc.names {
 				sink = sink.WithName(n)
 			}
@@ -489,7 +500,7 @@ func TestInfoWithValues(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cap := &capture{}
-			sink := newSink(cap.Func, Options{})
+			sink := newSink(cap.Func, NewFormatter(Options{}))
 			sink = sink.WithValues(tc.values...)
 			sink.Info(0, "msg", tc.args...)
 			if cap.log != tc.expect {
@@ -525,7 +536,7 @@ func TestErrorWithValues(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cap := &capture{}
-			sink := newSink(cap.Func, Options{})
+			sink := newSink(cap.Func, NewFormatter(Options{}))
 			sink = sink.WithValues(tc.values...)
 			sink.Error(fmt.Errorf("err"), "msg", tc.args...)
 			if cap.log != tc.expect {
@@ -538,7 +549,7 @@ func TestErrorWithValues(t *testing.T) {
 func TestInfoWithCallDepth(t *testing.T) {
 	t.Run("one", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: All})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All}))
 		dSink, _ := sink.(logr.CallDepthLogSink)
 		sink = dSink.WithCallDepth(1)
 		sink.Info(0, "msg")
@@ -553,7 +564,7 @@ func TestInfoWithCallDepth(t *testing.T) {
 func TestErrorWithCallDepth(t *testing.T) {
 	t.Run("one", func(t *testing.T) {
 		cap := &capture{}
-		sink := newSink(cap.Func, Options{LogCaller: All})
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All}))
 		dSink, _ := sink.(logr.CallDepthLogSink)
 		sink = dSink.WithCallDepth(1)
 		sink.Error(fmt.Errorf("err"), "msg")


### PR DESCRIPTION
New funcs `funcr.NewJSON()` and `funcr.NewFormatterJSON()` will
configure the output for strict JSON.  This is not just an `Options`
field because the function (from which funcr takes its name) has a
different signature in JSON mode (just 1 argument).

Benchmarks:

Before:
```
BenchmarkFuncrInfoOneArg-6               2015502               592.1 ns/op
BenchmarkFuncrInfoSeveralArgs-6           970407              1233 ns/op
BenchmarkFuncrV0Info-6                    970164              1232 ns/op
BenchmarkFuncrV9Info-6                  15342703                78.60 ns/op
BenchmarkFuncrError-6                     816357              1456 ns/op
```

After:
```
BenchmarkFuncrInfoOneArg-6               1998198               598.6 ns/op
BenchmarkFuncrJSONInfoOneArg-6           1727032               694.8 ns/op
BenchmarkFuncrInfoSeveralArgs-6           971455              1230 ns/op
BenchmarkFuncrJSONInfoSeveralArgs-6       889963              1344 ns/op
BenchmarkFuncrV0Info-6                    975469              1226 ns/op
BenchmarkFuncrJSONV0Info-6                890828              1342 ns/op
BenchmarkFuncrV9Info-6                  15004518                79.69 ns/op
BenchmarkFuncrJSONV9Info-6              15045549                79.86 ns/op
BenchmarkFuncrError-6                     816446              1462 ns/op
BenchmarkFuncrJSONError-6                 754684              1583 ns/op
```

The majority of the extra time in JSON mode seems to be from adding the
"logger" key-value pair, which I don't see how to improve on.

Fixes #98 