### PR TITLE
funcr: Pre-render WithValues() 

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -41,6 +41,16 @@ func doInfoSeveralArgs(b *testing.B, log logr.Logger) {
 }
 
 //go:noinline
+func doInfoWithValues(b *testing.B, log logr.Logger) {
+	log = log.WithValues("k1", "str", "k2", 222, "k3", true, "k4", 1.0)
+	for i := 0; i < b.N; i++ {
+		log.Info("multi",
+			"bool", true, "string", "str", "int", 42,
+			"float", 3.14, "struct", struct{ X, Y int }{93, 76})
+	}
+}
+
+//go:noinline
 func doV0Info(b *testing.B, log logr.Logger) {
 	for i := 0; i < b.N; i++ {
 		log.V(0).Info("multi",
@@ -102,6 +112,11 @@ func BenchmarkDiscardLogInfoSeveralArgs(b *testing.B) {
 	doInfoSeveralArgs(b, log)
 }
 
+func BenchmarkDiscardLogInfoWithValues(b *testing.B) {
+	var log logr.Logger = logr.Discard()
+	doInfoWithValues(b, log)
+}
+
 func BenchmarkDiscardLogV0Info(b *testing.B) {
 	var log logr.Logger = logr.Discard()
 	doV0Info(b, log)
@@ -148,6 +163,16 @@ func BenchmarkFuncrLogInfoSeveralArgs(b *testing.B) {
 func BenchmarkFuncrJSONLogInfoSeveralArgs(b *testing.B) {
 	var log logr.Logger = funcr.NewJSON(noopJSON, funcr.Options{})
 	doInfoSeveralArgs(b, log)
+}
+
+func BenchmarkFuncrLogInfoWithValues(b *testing.B) {
+	var log logr.Logger = funcr.New(noopKV, funcr.Options{})
+	doInfoWithValues(b, log)
+}
+
+func BenchmarkFuncrJSONLogInfoWithValues(b *testing.B) {
+	var log logr.Logger = funcr.NewJSON(noopJSON, funcr.Options{})
+	doInfoWithValues(b, log)
 }
 
 func BenchmarkFuncrLogV0Info(b *testing.B) {

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -201,7 +201,7 @@ func makeKV(args ...interface{}) []interface{} {
 	return args
 }
 
-func TestFlatten(t *testing.T) {
+func TestRender(t *testing.T) {
 	testCases := []struct {
 		name       string
 		kv         []interface{}
@@ -230,22 +230,26 @@ func TestFlatten(t *testing.T) {
 	}, {
 		name:       "non-string key",
 		kv:         makeKV(123, "val"),
-		expectKV:   `"<non-string-key-0>"="val"`,
-		expectJSON: `{"<non-string-key-0>":"val"}`,
+		expectKV:   `"<non-string-key>"="val"`,
+		expectJSON: `{"<non-string-key>":"val"}`,
 	}}
 
 	fKV := NewFormatter(Options{})
 	fJSON := NewFormatterJSON(Options{})
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := fKV.flatten(tc.kv...)
-			if r != tc.expectKV {
-				t.Errorf("expected %q, got %q", tc.expectKV, r)
-			}
-			r = fJSON.flatten(tc.kv...)
-			if r != tc.expectJSON {
-				t.Errorf("expected %q, got %q", tc.expectJSON, r)
-			}
+			t.Run("KV", func(t *testing.T) {
+				r := fKV.render(tc.kv, nil)
+				if r != tc.expectKV {
+					t.Errorf("wrong KV output:\nexpected %q\n     got %q", tc.expectKV, r)
+				}
+			})
+			t.Run("JSON", func(t *testing.T) {
+				r := fJSON.render(tc.kv, nil)
+				if r != tc.expectJSON {
+					t.Errorf("wrong JSON output:\nexpected %q\n     got %q", tc.expectJSON, r)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
This saves a potentially significant amount of time on each log call
(Info()/Error()) at the cost of making WithValues() slower.

Added a benchmark:

before:
```
BenchmarkFuncrLogInfoWithValues-6       	  644568	      1751 ns/op
BenchmarkFuncrJSONLogInfoWithValues-6   	  669440	      1788 ns/op
```

after:
```
BenchmarkFuncrLogInfoWithValues-6       	  868016	      1254 ns/op
BenchmarkFuncrJSONLogInfoWithValues-6   	  875338	      1363 ns/op
```

(builds on #101)