### PR TITLE
funcr: Fix bug in repeated calls to WithValues

### DIFF
--- a/funcr/example_test.go
+++ b/funcr/example_test.go
@@ -94,9 +94,10 @@ func ExampleOptions_renderHooks() {
 			RenderValuesHook:   valuesAsObject,
 		})
 	log = log.WithName("MyLogger")
-	log = log.WithValues("savedKey", "savedValue")
+	log = log.WithValues("savedKey1", "savedVal1")
+	log = log.WithValues("savedKey2", "savedVal2")
 	log.Info("the message", "key", "value")
-	// Output: {"log:logger":"MyLogger","log:level":0,"log:msg":"the message","labels":{"savedKey":"savedValue"},"key":"value"}
+	// Output: {"log:logger":"MyLogger","log:level":0,"log:msg":"the message","labels":{"savedKey1":"savedVal1","savedKey2":"savedVal2"},"key":"value"}
 }
 
 func ExamplePseudoStruct() {

--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -722,15 +722,16 @@ func (f *Formatter) AddName(name string) {
 func (f *Formatter) AddValues(kvList []interface{}) {
 	// Three slice args forces a copy.
 	n := len(f.values)
-	vals := f.values[:n:n]
-	vals = append(vals, kvList...)
+	f.values = append(f.values[:n:n], kvList...)
+
+	vals := f.values
 	if hook := f.opts.RenderValuesHook; hook != nil {
 		vals = hook(f.sanitize(vals))
 	}
 
 	// Pre-render values, so we don't have to do it on each Info/Error call.
 	buf := bytes.NewBuffer(make([]byte, 0, 1024))
-	f.values = f.flatten(buf, vals, false, true) // escape user-provided keys
+	f.flatten(buf, vals, false, true) // escape user-provided keys
 	f.valuesStr = buf.String()
 }
 


### PR DESCRIPTION
When using `RenderValuesHook` we need to save the raw value, not the
rendered form.

Fixes #120

@pohly let's not sit on it too long - we can tag a 1.2.1 maybe next week?

@DazWilkin FYI