### PR TITLE
funcr: Add a Callback type which defers arg eval

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -18,6 +18,7 @@ package logr_test
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
@@ -43,4 +44,12 @@ func Example() {
 	// "level"=0 "msg"="default info log" "stringVal"="value" "intVal"=12345
 	// "level"=0 "msg"="V(0) info log" "stringVal"="value" "intVal"=12345
 	// "msg"="error log" "error"="an error" "stringVal"="value" "intVal"=12345
+}
+
+func ExampleCallback() {
+	l := NewStdoutLogger()
+	long := "I have of late but wherefore I know not lost all my mirth"
+
+	l.Info("the message", "key", logr.Callback(func() interface{} { return strings.Fields(long)[5:9] }))
+	// Output: "level"=0 "msg"="the message" "key"=["wherefore","I","know","not"]
 }

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -574,6 +574,10 @@ func TestPretty(t *testing.T) {
 			},
 			exp: `{"[{\"S\":\"\\\"quoted\\\"\"},{\"S\":\"unquoted\"}]":1}`,
 		},
+		{
+			val: logr.Callback(func() interface{} { return []int{8, 6, 7, 5, 3, 0, 9} }),
+			exp: `[8,6,7,5,3,0,9]`,
+		},
 	}
 
 	f := NewFormatter(Options{})

--- a/logr.go
+++ b/logr.go
@@ -495,6 +495,9 @@ type CallStackHelperLogSink interface {
 // implement. Loggers with structured output, such as JSON, should
 // log the object return by the MarshalLog method instead of the
 // original value.
+//
+// Marshaler and Callback are mutually exclusive.  Even if MarshalLog
+// returns a Callback, the Callback will not be invoked.
 type Marshaler interface {
 	// MarshalLog can be used to:
 	//   - ensure that structs are not logged as strings when the original
@@ -508,3 +511,11 @@ type Marshaler interface {
 	// It may return any value of any type.
 	MarshalLog() interface{}
 }
+
+// Callback is a function which is called only when it is actually logged.  This
+// can be used to defer expensive operations when they might not be logged (for
+// example at higher V levels).
+//
+// Callback and Marshaler are mutually exclusive.  Even if the Callback returns
+// a Marshaler, the MarshalLog method will not be invoked.
+type Callback func() interface{}


### PR DESCRIPTION
This can be used to defer expensive argument processing (large strings,
allocations, etc) when they might not be logged, such as high V levels.
When they ARE logged, the `Callback` is executed and the result value
(which is itself evaluated for Stringer and so on) is logged.