### PR TITLE
testr: use an interface to make it work with *testing.B and *testing.F

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        version: [ '1.15', '1.16', '1.17' ]
+        version: [ '1.15', '1.16', '1.17', '1.18' ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/testr/testr_fuzz_test.go
+++ b/testr/testr_fuzz_test.go
@@ -1,0 +1,27 @@
+//go:build go1.18
+// +build go1.18
+
+/*
+Copyright 2022 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testr
+
+import "testing"
+
+func TestLoggerTestingF(t *testing.T) {
+	f := &testing.F{}
+	_ = NewWithInterface(f, Options{})
+}

--- a/testr/testr_test.go
+++ b/testr/testr_test.go
@@ -29,7 +29,8 @@ func TestLogger(t *testing.T) {
 	log.V(0).Info("V(0).info")
 	log.V(1).Info("v(1).info")
 	log.Error(fmt.Errorf("error"), "error")
-	log.WithName("testing").Info("with prefix")
+	log.WithName("testing").WithValues("value", "test").Info("with prefix")
+	log.WithName("testing").Error(fmt.Errorf("error"), "with prefix")
 	Helper(log, "hello world")
 
 	log = NewWithOptions(t, Options{
@@ -37,6 +38,42 @@ func TestLogger(t *testing.T) {
 		Verbosity:    1,
 	})
 	log.V(1).Info("v(1).info with options")
+
+	underlier, ok := log.GetSink().(Underlier)
+	if !ok {
+		t.Error("couldn't get underlier")
+	}
+	if t != underlier.GetUnderlying() {
+		t.Error("invalid underlier")
+	}
+}
+
+func TestLoggerInterface(t *testing.T) {
+	log := NewWithInterface(t, Options{})
+	log.Info("info")
+	log.V(0).Info("V(0).info")
+	log.V(1).Info("v(1).info")
+	log.Error(fmt.Errorf("error"), "error")
+	log.WithName("testing").WithValues("value", "test").Info("with prefix")
+	log.WithName("testing").Error(fmt.Errorf("error"), "with prefix")
+	Helper(log, "hello world")
+
+	underlier, ok := log.GetSink().(UnderlierInterface)
+	if !ok {
+		t.Fatal("couldn't get underlier")
+	}
+	underlierT, ok := underlier.GetUnderlying().(*testing.T)
+	if !ok {
+		t.Fatal("couldn't get underlying *testing.T")
+	}
+	if t != underlierT {
+		t.Error("invalid underlier")
+	}
+}
+
+func TestLoggerTestingB(t *testing.T) {
+	b := &testing.B{}
+	_ = NewWithInterface(b, Options{})
 }
 
 func Helper(log logr.Logger, msg string) {


### PR DESCRIPTION
The testr logger currently only works with `*testing.T` and is not usable in benchmarks and fuzz tests.
By using an interface instead, it can be made to accept `*testing.T`, `*testing.B` and `*testing.F`.

This is similar to what's done in other libraries, for example:

* https://github.com/kubernetes/klog/blob/a585df903e8653af246bcb8291cc856af2df9cfd/ktesting/testinglogger.go#L47
* https://github.com/stretchr/testify/blob/6990a05d54c2287be8787a411d77815643347339/require/requirements.go#L4
* https://github.com/ent/ent/blob/762e6aeff9d92f4b2af45932274401674462297f/entc/gen/template/enttest.tmpl#L32

This changes the return type of `GetUnderlying` though, so I'm not sure if that's OK.