### PR TITLE
If logging as JSON and the type is json.RawMessage log it "as-is"

### DIFF
--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -510,8 +510,7 @@ func (f Formatter) prettyWithFlags(value interface{}, flags uint32, depth int) s
 				if len(rm) > 0 {
 					buf.Write(rm)
 				} else {
-					buf.WriteByte('{')
-					buf.WriteByte('}')
+					buf.WriteString("null")
 				}
 				return buf.String()
 			}

--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -501,9 +501,9 @@ func (f Formatter) prettyWithFlags(value interface{}, flags uint32, depth int) s
 		}
 		return buf.String()
 	case reflect.Slice, reflect.Array:
-		// If this is emitting json make sure this isn't really a json.RawMessage. If so
-		// we can just emit "as-is" and don't pretty it as that will just escape it which
-		// defeats the purpose.
+		// If this is outputing as JSON make sure this isn't really a json.RawMessage.
+		// If so just emit "as-is" and don't pretty it as that will just print
+		// it as [X,Y,Z,...] which isn't terribly useful vs the string form you really want.
 		if f.outputFormat == outputJSON {
 			if rm, ok := value.(json.RawMessage); ok {
 				buf.Write(rm)

--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -37,6 +37,7 @@ package funcr
 import (
 	"bytes"
 	"encoding"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -500,6 +501,15 @@ func (f Formatter) prettyWithFlags(value interface{}, flags uint32, depth int) s
 		}
 		return buf.String()
 	case reflect.Slice, reflect.Array:
+		// If this is emitting json make sure this isn't really a json.RawMessage. If so
+		// we can just emit "as-is" and don't pretty it as that will just escape it which
+		// defeats the purpose.
+		if f.outputFormat == outputJSON {
+			if rm, ok := value.(json.RawMessage); ok {
+				buf.Write(rm)
+				return buf.String()
+			}
+		}
 		buf.WriteByte('[')
 		for i := 0; i < v.Len(); i++ {
 			if i > 0 {

--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -506,7 +506,13 @@ func (f Formatter) prettyWithFlags(value interface{}, flags uint32, depth int) s
 		// it as [X,Y,Z,...] which isn't terribly useful vs the string form you really want.
 		if f.outputFormat == outputJSON {
 			if rm, ok := value.(json.RawMessage); ok {
-				buf.Write(rm)
+				// If it's empty make sure we emit an empty value as the array style would below.
+				if len(rm) > 0 {
+					buf.Write(rm)
+				} else {
+					buf.WriteByte('{')
+					buf.WriteByte('}')
+				}
 				return buf.String()
 			}
 		}

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -230,6 +230,10 @@ type Tembedjsontags struct {
 	Tinner6 `json:"inner6,omitempty"`
 }
 
+type Trawjson struct {
+	Message json.RawMessage `json:"message"`
+}
+
 func TestPretty(t *testing.T) {
 	// used below
 	newStr := func(s string) *string {
@@ -669,6 +673,15 @@ func makeKV(args ...interface{}) []interface{} {
 }
 
 func TestRender(t *testing.T) {
+	// used below
+	raw := &Trawjson{}
+	marshal := &TjsontagsInt{}
+	var err error
+	raw.Message, err = json.Marshal(marshal)
+	if err != nil {
+		t.Fatalf("json.Marshal error: %v", err)
+	}
+
 	testCases := []struct {
 		name       string
 		builtins   []interface{}
@@ -738,6 +751,16 @@ func TestRender(t *testing.T) {
 		}{"arg", 789}, "val"),
 		expectKV:   `"<non-string-key: {"F1":"builtin",>"="val" "<non-string-key: {\"F1\":\"value\",\"F>"="val" "<non-string-key: {\"F1\":\"arg\",\"F2\">"="val"`,
 		expectJSON: `{"<non-string-key: {"F1":"builtin",>":"val","<non-string-key: {\"F1\":\"value\",\"F>":"val","<non-string-key: {\"F1\":\"arg\",\"F2\">":"val"}`,
+	}, {
+		name:       "json rendering with json.RawMessage",
+		args:       makeKV("key", raw),
+		expectKV:   `"key"={"message":[123,34,105,110,116,49,34,58,48,44,34,45,34,58,48,44,34,73,110,116,53,34,58,48,125]}`,
+		expectJSON: `{"key":{"message":{"int1":0,"-":0,"Int5":0}}}`,
+	}, {
+		name:       "byte array not json.RawMessage",
+		args:       makeKV("key", []byte{1, 2, 3, 4}),
+		expectKV:   `"key"=[1,2,3,4]`,
+		expectJSON: `{"key":[1,2,3,4]}`,
 	}}
 
 	for _, tc := range testCases {

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -761,6 +761,16 @@ func TestRender(t *testing.T) {
 		args:       makeKV("key", []byte{1, 2, 3, 4}),
 		expectKV:   `"key"=[1,2,3,4]`,
 		expectJSON: `{"key":[1,2,3,4]}`,
+	}, {
+		name:       "json rendering with empty json.RawMessage",
+		args:       makeKV("key", &Trawjson{}),
+		expectKV:   `"key"={"message":[]}`,
+		expectJSON: `{"key":{"message":{}}}`,
+	}, {
+		name:       "byte array not json.RawMessage",
+		args:       makeKV("key", []byte{1, 2, 3, 4}),
+		expectKV:   `"key"=[1,2,3,4]`,
+		expectJSON: `{"key":[1,2,3,4]}`,
 	}}
 
 	for _, tc := range testCases {

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -766,11 +766,6 @@ func TestRender(t *testing.T) {
 		args:       makeKV("key", &Trawjson{}),
 		expectKV:   `"key"={"message":[]}`,
 		expectJSON: `{"key":{"message":null}}`,
-	}, {
-		name:       "byte array not json.RawMessage",
-		args:       makeKV("key", []byte{1, 2, 3, 4}),
-		expectKV:   `"key"=[1,2,3,4]`,
-		expectJSON: `{"key":[1,2,3,4]}`,
 	}}
 
 	for _, tc := range testCases {

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -765,7 +765,7 @@ func TestRender(t *testing.T) {
 		name:       "json rendering with empty json.RawMessage",
 		args:       makeKV("key", &Trawjson{}),
 		expectKV:   `"key"={"message":[]}`,
-		expectJSON: `{"key":{"message":{}}}`,
+		expectJSON: `{"key":{"message":null}}`,
 	}, {
 		name:       "byte array not json.RawMessage",
 		args:       makeKV("key", []byte{1, 2, 3, 4}),

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-logr/logr
+module github.com/sfc-gh-jchacon/logr
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sfc-gh-jchacon/logr
+module github.com/go-logr/logr
 
 go 1.16


### PR DESCRIPTION
If we're already producing JSON and a sub message field is json.RawMessage (i.e. []byte) then emit it as-is.

Otherwise you get [X,Y,Z,..] style which is pretty useless in the log in that form.