### PR TITLE
Remove genericr from the list of interface implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ There are implementations for the following logging libraries:
 - **go.uber.org/zap**: [zapr](https://github.com/go-logr/zapr)
 - **log** (the Go standard library logger): [stdr](https://github.com/go-logr/stdr)
 - **github.com/sirupsen/logrus**: [logrusr](https://github.com/bombsimon/logrusr)
-- **github.com/wojas/genericr**: [genericr](https://github.com/wojas/genericr) (makes it easy to implement your own backend)
 - **logfmt** (Heroku style [logging](https://www.brandur.org/logfmt)): [logfmtr](https://github.com/iand/logfmtr)
 - **github.com/rs/zerolog**: [zerologr](https://github.com/go-logr/zerologr)
 - **github.com/go-kit/log**: [gokitlogr](https://github.com/tonglil/gokitlogr) (also compatible with github.com/go-kit/kit/log since v0.12.0)


### PR DESCRIPTION
Remove genericr from the list of interface implementations.

It's incompatible with logr < 1.0.0, and hasn't been updated in 2+ years.

See wojas/genericr#2
