### PR TITLE
add KeysAndValues as special type

### DIFF
--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -419,6 +419,24 @@ func (f Formatter) prettyWithFlags(value interface{}, flags uint32, depth int) s
 			buf.WriteByte('}')
 		}
 		return buf.String()
+	case logr.KeysAndValues:
+		buf := bytes.NewBuffer(make([]byte, 0, 1024))
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('{')
+		}
+		for i, keyAndValue := range v {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			// arbitrary keys might need escaping
+			buf.WriteString(prettyString(keyAndValue.Key))
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(keyAndValue.Value, 0, depth+1))
+		}
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('}')
+		}
+		return buf.String()
 	}
 
 	buf := bytes.NewBuffer(make([]byte, 0, 256))

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -721,9 +721,16 @@ func TestRender(t *testing.T) {
 		name:       "pseudo structs",
 		builtins:   makeKV("int", PseudoStruct(makeKV("intsub", 1))),
 		values:     makeKV("str", PseudoStruct(makeKV("strsub", "2"))),
-		args:       makeKV("bool", PseudoStruct(makeKV("boolsub", true))),
-		expectKV:   `"int"={"intsub":1} "str"={"strsub":"2"} "bool"={"boolsub":true}`,
-		expectJSON: `{"int":{"intsub":1},"str":{"strsub":"2"},"bool":{"boolsub":true}}`,
+		args:       makeKV("many", PseudoStruct(makeKV("boolsub", true, "intsub", 1, "recursive", PseudoStruct(makeKV("sub", "level2"))))),
+		expectKV:   `"int"={"intsub":1} "str"={"strsub":"2"} "many"={"boolsub":true,"intsub":1,"recursive":{"sub":"level2"}}`,
+		expectJSON: `{"int":{"intsub":1},"str":{"strsub":"2"},"many":{"boolsub":true,"intsub":1,"recursive":{"sub":"level2"}}}`,
+	}, {
+		name:       "KeysAndValues",
+		builtins:   makeKV("int", logr.KeysAndValues{{"sub", 1}}),
+		values:     makeKV("str", logr.KeysAndValues{{"sub", "2"}}),
+		args:       makeKV("many", logr.KeysAndValues{{"boolsub", true}, {"intsub", 1}, {"recursive", logr.KeysAndValues{{"sub", "level2"}}}}),
+		expectKV:   `"int"={"sub":1} "str"={"sub":"2"} "many"={"boolsub":true,"intsub":1,"recursive":{"sub":"level2"}}`,
+		expectJSON: `{"int":{"sub":1},"str":{"sub":"2"},"many":{"boolsub":true,"intsub":1,"recursive":{"sub":"level2"}}}`,
 	}, {
 		name:       "escapes",
 		builtins:   makeKV("\"1\"", 1),     // will not be escaped, but should never happen

--- a/logr.go
+++ b/logr.go
@@ -533,3 +533,19 @@ type Marshaler interface {
 	// It may return any value of any type.
 	MarshalLog() interface{}
 }
+
+// KeysAndValues is a special type that will get logged like a struct. The
+// main advantage is that keys and values can get constructed dynamically and
+// that some LogSinks may render it more nicely than plain structs.
+//
+// Not all LogSinks support this special type. Those that don't
+// will log it like an array.
+type KeysAndValues []KeyAndValue
+
+// KeyAndValue is one entry in KeysAndValues.
+type KeyAndValue struct {
+	// Key is used to log the value.
+	Key string
+	// Value is an arbitrary value that is to be logged.
+	Value interface{}
+}


### PR DESCRIPTION
This is like the existing funcr.PseudoStruct except that it uses structs as members of the slice. The reasons for that difference are making the API type-safe at compile time and (subjectively) nicer rendering when a LogSink does not support the type.

Here's how zapr and klogr handle funcr.PseudoStruct:

    {"caller":"test/output.go:435","msg":"funcr","v":0,"parent":["a",1,"b",2]}
    I output.go:486] "funcr" parent=[a 1 b 2]

Here's the same for logr.KeysAndValues:

    {"caller":"test/output.go:435","msg":"keys and values","v":0,"parent":[{"Key":"a","Value":1},{"Key":"b","Value":2}]}
    I output.go:486] "keys and values" parent=[{Key:a Value:1} {Key:b Value:2}]

The tentative support for logr.KeysAndValues would lead to output like this:

    {"caller":"test/output.go:<LINE>","msg":"keys and values","v":0,"parent":{"boolsub":true,"intsub":1,"recursive":[{"Key":"sub","Value":"level2"}]}}
    I output.go:<LINE>] "keys and values" parent={ boolsub=true intsub=1 recursive={ sub="level2" } }

The implementation in klogr is recursive and handles KeysAndValues nested inside KeysAndValues, the one in zapr is simpler and only handles it at the top level.