### PR TITLE
funcr: optimize WithValues/WithName/WithCallDepth

### DIFF
--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -218,7 +218,7 @@ func newFormatter(opts Options, outfmt outputFormat) Formatter {
 		prefix:       "",
 		values:       nil,
 		depth:        0,
-		opts:         opts,
+		opts:         &opts,
 	}
 	return f
 }
@@ -232,7 +232,7 @@ type Formatter struct {
 	values       []interface{}
 	valuesStr    string
 	depth        int
-	opts         Options
+	opts         *Options
 }
 
 // outputFormat indicates which outputFormat to use.


### PR DESCRIPTION
All of these functions indirectly copied the entire Options struct because it gets stored by value in the Formatter and thus fnlogger. The struct is read-only, therefore sharing a single copy by pointer via different logger instances is possible. Performance for the context value benchmark got better.