### PR TITLE
WIP: funcr: split out PseudoStruct into separate package

### DIFF
--- a/funcr/funcr.go
+++ b/funcr/funcr.go
@@ -47,6 +47,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	funcrtypes "github.com/go-logr/logr/funcr/types"
 )
 
 // New returns a logr.Logger which is implemented by an arbitrary function.
@@ -246,7 +247,7 @@ const (
 )
 
 // PseudoStruct is a list of key-value pairs that gets logged as a struct.
-type PseudoStruct []interface{}
+type PseudoStruct = funcrtypes.PseudoStruct
 
 // render produces a log line, ready to use.
 func (f Formatter) render(builtins, args []interface{}) string {

--- a/funcr/types/types.go
+++ b/funcr/types/types.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package types provides type definitions for funcr that may also be useful
+// without the funcr implementation.
+package types
+
+// PseudoStruct is a list of key-value pairs that gets logged as a struct.
+type PseudoStruct []interface{}


### PR DESCRIPTION
This makes it possible to reference it in other LogSinks which want to provide the same functionality without pulling in the funcr source code.

Doing the same with current master results in "go mod vendor" including "funcr.go" under "vendor".
