### PR TITLE
Add minimal permissions to workflows

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -1,6 +1,6 @@
 name: Run apidiff
 
-on: [pull_request]
+on: [ pull_request ]
 
 permissions:
   contents: read

--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -1,6 +1,9 @@
 name: Run apidiff
 
-on: [ pull_request ]
+on: [pull_request]
+
+permissions:
+  contents: read
 
 jobs:
   apidiff:

--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   assign:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -6,6 +6,9 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   assign:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,9 @@
 name: Run lint
 
-on: [ push, pull_request ]
+on: [push, pull_request]
+
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 name: Run lint
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,6 @@
 name: Run tests
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 permissions:
   contents: read
@@ -9,17 +9,17 @@ jobs:
   test:
     strategy:
       matrix:
-        version: ["1.15", "1.16", "1.17", "1.18"]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        version: [ '1.15', '1.16', '1.17', '1.18' ]
+        platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.version }}
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Build
-        run: go build -v ./...
-      - name: Test
-        run: go test -v -race ./...
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Build
+      run: go build -v ./...
+    - name: Test
+      run: go test -v -race ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,22 +1,25 @@
 name: Run tests
 
-on: [ push, pull_request ]
+on: [push, pull_request]
+
+permissions:
+  contents: read
 
 jobs:
   test:
     strategy:
       matrix:
-        version: [ '1.15', '1.16', '1.17', '1.18' ]
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+        version: ["1.15", "1.16", "1.17", "1.18"]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Build
-      run: go build -v ./...
-    - name: Test
-      run: go test -v -race ./...
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v -race ./...


### PR DESCRIPTION
Fixes #176.

As described in the linked issue, this PR sets all workflows with minimal permissions. This reduces the threat from supply-chain attacks.