### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send us a [private vulnerability report](https://github.com/go-logr/logr/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+We ask that you give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #179.

As described in the issue, this PR adds a security policy to the project.

It currently offers two means of reporting: via an email (currently a placeholder) or using GitHub's private reporting feature (which must be enabled to work). It also suggests a 90-day remediation timeline, which is pretty standard.

If you'd rather change something (only offer one reporting method, add an actual email, use an external website instead, change the timeline, etc), let me know and I'll happily modify the PR.