### PR TITLE
WIP: trigger `var is unused`

### DIFF
--- a/logr.go
+++ b/logr.go
@@ -548,3 +548,5 @@ type Marshaler interface {
 	// It may return any value of any type.
 	MarshalLog() interface{}
 }
+
+var unused = 1


### PR DESCRIPTION
This PR should trigger:
```
logr.go:552:5: var `unused` is unused (unused)
var unused = 1
    ^
```

I am wondering whether the golangci-lint action still has permission to post that as annotation (https://github.com/go-logr/logr/pull/177/files#r1212878261).