### PR TITLE
WIP: slog support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        version: [ '1.15', '1.16', '1.17', '1.18' ]
+        version: [ '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21.0-rc.4' ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/context.go
+++ b/context.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+// contextKey is how we find loggers in a context.Context.
+type contextKey struct{}
+
+// notFoundError exists to carry an IsNotFound method.
+type notFoundError struct{}
+
+func (notFoundError) Error() string {
+	return "no logger was present"
+}
+
+func (notFoundError) IsNotFound() bool {
+	return true
+}

--- a/context_noslog.go
+++ b/context_noslog.go
@@ -1,0 +1,52 @@
+//go:build !go1.21
+// +build !go1.21
+
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+import (
+	"context"
+)
+
+// This file contains the version of NewContext and FromContext which supports
+// only storing and retrieving a Logger.
+
+// FromContext returns a Logger from ctx or an error if no Logger is found.
+func FromContext(ctx context.Context) (Logger, error) {
+	if v, ok := ctx.Value(contextKey{}).(Logger); ok {
+		return v, nil
+	}
+
+	return Logger{}, notFoundError{}
+}
+
+// FromContextOrDiscard returns a Logger from ctx.  If no Logger is found, this
+// returns a Logger that discards all log messages.
+func FromContextOrDiscard(ctx context.Context) Logger {
+	if v, ok := ctx.Value(contextKey{}).(Logger); ok {
+		return v
+	}
+
+	return Discard()
+}
+
+// NewContext returns a new Context, derived from ctx, which carries the
+// provided Logger.
+func NewContext(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, logger)
+}

--- a/context_slog.go
+++ b/context_slog.go
@@ -1,0 +1,123 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+import (
+	"context"
+	"log/slog"
+)
+
+// This file contains the version of NewContext and FromContext which supports
+// storing different types of loggers and converts as needed when retrieving
+// the most recent one.
+
+// FromContext returns a Logger from ctx or an error if no Logger is found.
+func FromContext(ctx context.Context) (Logger, error) {
+	l := ctx.Value(contextKey{})
+
+	switch l := l.(type) {
+	case Logger:
+		return l, nil
+	case *slog.Logger:
+		return FromSlog(l), nil
+	case slog.Handler:
+		return FromSlogHandler(l), nil
+	}
+
+	return Logger{}, notFoundError{}
+}
+
+// FromContextOrDiscard returns a Logger from ctx.  If no Logger is found, this
+// returns a Logger that discards all log messages.
+func FromContextOrDiscard(ctx context.Context) Logger {
+	l, err := FromContext(ctx)
+	if err != nil {
+		return Discard()
+	}
+	return l
+}
+
+// SlogFromContext is a variant of FromContext that returns a slog.Logger.
+func SlogFromContext(ctx context.Context) (*slog.Logger, error) {
+	l := ctx.Value(contextKey{})
+
+	switch l := l.(type) {
+	case Logger:
+		return ToSlog(l), nil
+	case *slog.Logger:
+		return l, nil
+	case slog.Handler:
+		return slog.New(l), nil
+	}
+
+	return nil, notFoundError{}
+}
+
+// SlogFromContextOrDiscard is a variant of FromContextOrDiscard that returns a slog.Logger.
+func SlogFromContextOrDiscard(ctx context.Context) *slog.Logger {
+	l, err := SlogFromContext(ctx)
+	if err != nil {
+		return ToSlog(Discard()) // TODO: use something simpler
+	}
+	return l
+}
+
+// SlogHandlerFromContext is a variant of FromContext that returns a slog.Handler.
+func SlogHandlerFromContext(ctx context.Context) (slog.Handler, error) {
+	l := ctx.Value(contextKey{})
+
+	switch l := l.(type) {
+	case Logger:
+		return ToSlogHandler(l), nil
+	case *slog.Logger:
+		return l.Handler(), nil
+	case slog.Handler:
+		return l, nil
+	}
+
+	return nil, notFoundError{}
+}
+
+// SlogHandlerFromContextOrDiscard is a variant of FromContextOrDiscard that returns a slog.Handler.
+func SlogHandlerFromContextOrDiscard(ctx context.Context) slog.Handler {
+	l, err := SlogHandlerFromContext(ctx)
+	if err != nil {
+		return ToSlog(Discard()).Handler() // TODO: use something simpler
+	}
+	return l
+}
+
+// NewContext returns a new Context, derived from ctx, which carries the
+// provided Logger.
+func NewContext(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, logger)
+}
+
+// SlogNewContext returns a new Context, derived from ctx, which carries the
+// provided slog.Logger.
+func SlogNewContext(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, logger)
+}
+
+// SlogHandlerNewContext returns a new Context, derived from ctx, which carries the
+// provided slog.Handler.
+func SlogHandlerNewContext(ctx context.Context, handler slog.Handler) context.Context {
+	return context.WithValue(ctx, contextKey{}, handler)
+}

--- a/logr.go
+++ b/logr.go
@@ -207,10 +207,6 @@ limitations under the License.
 // those.
 package logr
 
-import (
-	"context"
-)
-
 // New returns a new Logger instance.  This is primarily used by libraries
 // implementing LogSink, rather than end users.  Passing a nil sink will create
 // a Logger which discards all log lines.
@@ -395,45 +391,6 @@ func (l Logger) WithCallStackHelper() (func(), Logger) {
 // IsZero returns true if this logger is an uninitialized zero value
 func (l Logger) IsZero() bool {
 	return l.sink == nil
-}
-
-// contextKey is how we find Loggers in a context.Context.
-type contextKey struct{}
-
-// FromContext returns a Logger from ctx or an error if no Logger is found.
-func FromContext(ctx context.Context) (Logger, error) {
-	if v, ok := ctx.Value(contextKey{}).(Logger); ok {
-		return v, nil
-	}
-
-	return Logger{}, notFoundError{}
-}
-
-// notFoundError exists to carry an IsNotFound method.
-type notFoundError struct{}
-
-func (notFoundError) Error() string {
-	return "no logr.Logger was present"
-}
-
-func (notFoundError) IsNotFound() bool {
-	return true
-}
-
-// FromContextOrDiscard returns a Logger from ctx.  If no Logger is found, this
-// returns a Logger that discards all log messages.
-func FromContextOrDiscard(ctx context.Context) Logger {
-	if v, ok := ctx.Value(contextKey{}).(Logger); ok {
-		return v
-	}
-
-	return Discard()
-}
-
-// NewContext returns a new Context, derived from ctx, which carries the
-// provided Logger.
-func NewContext(ctx context.Context, logger Logger) context.Context {
-	return context.WithValue(ctx, contextKey{}, logger)
 }
 
 // RuntimeInfo holds information that the logr "core" library knows which

--- a/slog.go
+++ b/slog.go
@@ -1,0 +1,81 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+import (
+	"log/slog"
+)
+
+// SlogImplementor is an interface that a logr.LogSink can implement
+// to support efficient logging through the slog.Logger API.
+type SlogImplementor interface {
+	// GetSlogHandler returns a handler which uses the same settings as the logr.LogSink.
+	GetSlogHandler() slog.Handler
+}
+
+// LogrImplementor is an interface that a slog.Handler can implement
+// to support efficient logging through the logr.Logger API.
+type LogrImplementor interface {
+	// GetLogrLogSink returns a sink which uses the same settings as the slog.Handler.
+	GetLogrLogSink() LogSink
+}
+
+// ToSlog returns a slog.Logger which writes to the same backend as the logr.Logger.
+func ToSlog(logger Logger) *slog.Logger {
+	return slog.New(ToSlogHandler(logger))
+}
+
+// ToSlog returns a slog.Handler which writes to the same backend as the logr.Logger.
+func ToSlogHandler(logger Logger) slog.Handler {
+	if slogImplementor, ok := logger.GetSink().(SlogImplementor); ok {
+		handler := slogImplementor.GetSlogHandler()
+		return handler
+	}
+
+	return &slogHandler{sink: logger.GetSink()}
+}
+
+// FromSlog returns a logr.Logger which writes to the same backend as the slog.Logger.
+func FromSlog(logger *slog.Logger) Logger {
+	return FromSlogHandler(logger.Handler())
+}
+
+// FromSlog returns a logr.Logger which writes to the same backend as the slog.Handler.
+func FromSlogHandler(handler slog.Handler) Logger {
+	if logrImplementor, ok := handler.(LogrImplementor); ok {
+		logSink := logrImplementor.GetLogrLogSink()
+		return New(logSink)
+	}
+
+	return New(&slogSink{handler: handler})
+}
+
+func levelFromSlog(level slog.Level) int {
+	if level >= 0 {
+		// logr has no level lower than 0, so we have to truncate.
+		return 0
+	}
+	return int(-level)
+}
+
+func levelToSlog(level int) slog.Level {
+	// logr starts at info = 0 and higher values go towards debugging (negative in slog).
+	return slog.Level(-level)
+}

--- a/slog_test.go
+++ b/slog_test.go
@@ -1,0 +1,72 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr_test
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+)
+
+var debugWithoutTime = &slog.HandlerOptions{
+	ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+		if a.Key == "time" {
+			return slog.Attr{}
+		}
+		return a
+	},
+	Level: slog.LevelDebug,
+}
+
+func ExampleFromSlog() {
+	logger := logr.FromSlog(slog.New(slog.NewTextHandler(os.Stdout, debugWithoutTime)))
+
+	logger.Info("hello world")
+	logger.Error(errors.New("fake error"), "ignore me")
+	logger.WithValues("x", 1, "y", 2).WithValues("str", "abc").WithName("foo").WithName("bar").V(4).Info("with values, verbosity and name")
+
+	// Output:
+	// level=INFO msg="hello world"
+	// level=ERROR msg="ignore me" err="fake error"
+	// level=DEBUG msg="foo/bar: with values, verbosity and name" x=1 y=2 str=abc
+}
+
+func ExampleToSlog() {
+	logger := logr.ToSlog(funcr.New(func(prefix, args string) {
+		if prefix != "" {
+			fmt.Fprintln(os.Stdout, prefix, args)
+		} else {
+			fmt.Fprintln(os.Stdout, args)
+		}
+	}, funcr.Options{}))
+
+	logger.Info("hello world")
+	logger.Error("ignore me", "err", errors.New("fake error"))
+	logger.With("x", 1, "y", 2).WithGroup("group").With("str", "abc").Warn("with values and group")
+
+	// Output:
+	// "level"=0 "msg"="hello world"
+	// "msg"="ignore me" "error"=null "err"="fake error"
+	// "level"=0 "msg"="with values and group" "x"=1 "y"=2 "group.str"="abc"
+}

--- a/sloghandler.go
+++ b/sloghandler.go
@@ -1,0 +1,71 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+import (
+	"context"
+	"log/slog"
+)
+
+type slogHandler struct {
+	sink        LogSink
+	groupPrefix string
+}
+
+func (l *slogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return l.sink.Enabled(levelFromSlog(level))
+}
+
+func (l *slogHandler) Handle(ctx context.Context, record slog.Record) error {
+	kvList := make([]any, 0, 2*record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		kvList = append(kvList, appendPrefix(l.groupPrefix, attr.Key), attr.Value.Any())
+		return true
+	})
+	if record.Level >= slog.LevelError {
+		l.sink.Error(nil, record.Message, kvList...)
+	} else {
+		l.sink.Info(levelFromSlog(record.Level), record.Message, kvList...)
+	}
+	return nil
+}
+
+func (l slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	kvList := make([]any, 0, 2*len(attrs))
+	for _, attr := range attrs {
+		kvList = append(kvList, appendPrefix(l.groupPrefix, attr.Key), attr.Value.Any())
+	}
+	l.sink = l.sink.WithValues(kvList...)
+	return &l
+}
+
+func (l slogHandler) WithGroup(name string) slog.Handler {
+	l.groupPrefix = appendPrefix(l.groupPrefix, name)
+	return &l
+}
+
+func appendPrefix(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return prefix + "." + name
+}
+
+var _ slog.Handler = &slogHandler{}

--- a/slogsink.go
+++ b/slogsink.go
@@ -1,0 +1,106 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"time"
+)
+
+type slogSink struct {
+	callDepth int
+	prefix    string
+	handler   slog.Handler
+}
+
+func (l *slogSink) Init(info RuntimeInfo) {
+	l.callDepth = info.CallDepth
+}
+
+func (l *slogSink) WithCallDepth(depth int) LogSink {
+	newLogger := *l
+	newLogger.callDepth += depth
+	return &newLogger
+}
+
+func (l *slogSink) Enabled(level int) bool {
+	return l.handler.Enabled(context.Background(), levelToSlog(level))
+}
+
+func (l *slogSink) Info(level int, msg string, kvList ...interface{}) {
+	if l.prefix != "" {
+		msg = l.prefix + ": " + msg
+	}
+	record := slog.NewRecord(time.Now(), levelToSlog(level), msg, l.infoOrErrorCaller())
+	record.Add(kvList...)
+	l.handler.Handle(context.Background(), record)
+}
+
+func (l *slogSink) Error(err error, msg string, kvList ...interface{}) {
+	if l.prefix != "" {
+		msg = l.prefix + ": " + msg
+	}
+	record := slog.NewRecord(time.Now(), slog.LevelError, msg, l.infoOrErrorCaller())
+	if err != nil {
+		record.Add("err", err)
+	}
+	record.Add(kvList...)
+	l.handler.Handle(context.Background(), record)
+}
+
+func (l *slogSink) WithName(name string) LogSink {
+	new := *l
+	if l.prefix != "" {
+		new.prefix = l.prefix + "/"
+	}
+	new.prefix += name
+	return &new
+}
+
+func (l *slogSink) WithValues(kvList ...interface{}) LogSink {
+	new := *l
+	new.handler = l.handler.WithAttrs(kvListToAttrs(kvList...))
+	return &new
+}
+
+// infoOrErrorCaller is a helper for Info and Error.
+func (l *slogSink) infoOrErrorCaller() uintptr {
+	var pcs [1]uintptr
+	// skip [runtime.Callers, this function, Info/Error, and all helper functions above that.
+	runtime.Callers(4+l.callDepth, pcs[:])
+	return pcs[0]
+}
+
+func kvListToAttrs(kvList ...interface{}) []slog.Attr {
+	// We don't need the record itself, only its Add method.
+	record := slog.NewRecord(time.Time{}, 0, "", 0)
+	record.Add(kvList...)
+	attrs := make([]slog.Attr, 0, record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs = append(attrs, attr)
+		return true
+	})
+	return attrs
+}
+
+var _ LogSink = &slogSink{}
+var _ CallDepthLogSink = &slogSink{}


### PR DESCRIPTION
This adds APIs for converting between a logr.Logger and a slog.Logger. Glue code is needed in some cases.

The reasons for doing this in logr itself are a) easy access to the new API calls and b) it enables a future logr extension where logr itself manages a global default logger which can be provided by either a slog.Handler or a logr.LogSink, with conversion as needed by a client.

Since it was created, this PR was split into smaller PRs and will not get merged itself. I'm keeping it around as reference until everything is merged:
- [x] glue code: https://github.com/go-logr/logr/pull/205
- [x] conversion: https://github.com/go-logr/logr/pull/210
- [x] better slog support through special support in sinks ("SlogSink"): https://github.com/go-logr/logr/pull/211
- [ ] context support (optional): https://github.com/go-logr/logr/pull/213

Fixes: https://github.com/go-logr/logr/issues/171