### PR TITLE
Use same call depth for Enabled, Info, Error

### DIFF
--- a/logr.go
+++ b/logr.go
@@ -258,6 +258,12 @@ type Logger struct {
 // Enabled tests whether this Logger is enabled.  For example, commandline
 // flags might be used to set the logging verbosity and disable some info logs.
 func (l Logger) Enabled() bool {
+	// Some implementations of LogSink look at the caller in Enabled (e.g.
+	// different verbosity levels per package or file), but we only pass one
+	// CallDepth in (via Init).  This means that all calls from Logger to the
+	// LogSink's Enabled, Info, and Error methods must have the same number of
+	// frames.  In other words, Logger methods can't call other Logger methods
+	// which call these LogSink methods unless we do it the same in all paths.
 	return l.sink != nil && l.sink.Enabled(l.level)
 }
 
@@ -271,7 +277,7 @@ func (l Logger) Info(msg string, keysAndValues ...any) {
 	if l.sink == nil {
 		return
 	}
-	if l.Enabled() {
+	if l.sink.Enabled(l.level) { // see comment in Enabled
 		if withHelper, ok := l.sink.(CallStackHelperLogSink); ok {
 			withHelper.GetCallStackHelper()()
 		}


### PR DESCRIPTION
klog does stack unwinding in `LogSink.Enabled` to implement per-source code verbosity thresholds (`-vmodule`). This worked for `logger.Info` and `logger.Error` because the code was written such that it matches how logr is implemented (Logger.Info -> Logger.Enabled -> LogSink.Enabled).

It did not work for direct calls (`if logger.Enabled`) because then the call chain is `Logger.Enabled -> LogSink.Enabled`.  Now it uses the same depth (as passed to LogSink.Init) for all paths to Enabled.

NOTE: callers who have worked around this bug will need to remove their workarounds.

Fixes #215
Alternative to #216 