### PR TITLE
RFC: define debug level and helper method

### DIFF
--- a/logr.go
+++ b/logr.go
@@ -207,6 +207,11 @@ limitations under the License.
 // those.
 package logr
 
+const (
+	// LevelDebug corresponds to slog.LevelDebug.
+	LevelDebug = 4
+)
+
 // New returns a new Logger instance.  This is primarily used by libraries
 // implementing LogSink, rather than end users.  Passing a nil sink will create
 // a Logger which discards all log lines.
@@ -278,6 +283,22 @@ func (l Logger) Info(msg string, keysAndValues ...any) {
 			withHelper.GetCallStackHelper()()
 		}
 		l.sink.Info(l.level, msg, keysAndValues...)
+	}
+}
+
+// Debug is a convenience function. It's equivalent to
+//
+//	V(LevelDebug).Info
+func (l Logger) Debug(msg string, keysAndValues ...any) {
+	if l.sink == nil {
+		return
+	}
+	level := l.level + LevelDebug
+	if l.sink.Enabled(level) { // see comment in Enabled
+		if withHelper, ok := l.sink.(CallStackHelperLogSink); ok {
+			withHelper.GetCallStackHelper()()
+		}
+		l.sink.Info(level, msg, keysAndValues...)
 	}
 }
 

--- a/logr_test.go
+++ b/logr_test.go
@@ -233,7 +233,7 @@ func TestInfo(t *testing.T) {
 	sink := &testLogSink{}
 	sink.fnEnabled = func(lvl int) bool {
 		calledEnabled++
-		return lvl < 100
+		return lvl < 4
 	}
 	sink.fnInfo = func(lvl int, msg string, kv ...any) {
 		calledInfo++
@@ -273,8 +273,8 @@ func TestInfo(t *testing.T) {
 
 	calledEnabled = 0
 	calledInfo = 0
-	lvlInput = 93
-	logger.V(93).Info(msgInput, kvInput...)
+	lvlInput = 3
+	logger.V(3).Info(msgInput, kvInput...)
 	if calledEnabled != 1 {
 		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
 	}
@@ -284,8 +284,30 @@ func TestInfo(t *testing.T) {
 
 	calledEnabled = 0
 	calledInfo = 0
-	lvlInput = 100
-	logger.V(100).Info(msgInput, kvInput...)
+	lvlInput = 4
+	logger.V(4).Info(msgInput, kvInput...)
+	if calledEnabled != 1 {
+		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
+	}
+	if calledInfo != 0 {
+		t.Errorf("expected sink.Info() to not be called, got %d", calledInfo)
+	}
+
+	calledEnabled = 0
+	calledInfo = 0
+	lvlInput = 4
+	logger.V(4).Info(msgInput, kvInput...)
+	if calledEnabled != 1 {
+		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
+	}
+	if calledInfo != 0 {
+		t.Errorf("expected sink.Info() to not be called, got %d", calledInfo)
+	}
+
+	calledEnabled = 0
+	calledInfo = 0
+	lvlInput = 4
+	logger.Debug(msgInput, kvInput...)
 	if calledEnabled != 1 {
 		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
 	}
@@ -497,6 +519,7 @@ func TestCallDepthConsistent(t *testing.T) {
 	l := New(sink)
 
 	l.Enabled()
+	l.Debug("msg")
 	l.Info("msg")
 	l.Error(nil, "msg")
 }


### PR DESCRIPTION
Traditionally, logr has not had pre-defined levels and left the choice of consistent levels to users. When Go introduced slog, some standardized numeric levels were defined.

logr doesn't support levels "more important" than 0, but "debug" = 4 = -slog.LevelDebug is possible. To ensure alignment with slog it makes sense to define that level as a special constant (for use with V) and to have a helper function which corresponds to V(4).Info.