### PR TITLE
sloghandler: unnamed groups should be inlined

### DIFF
--- a/sloghandler.go
+++ b/sloghandler.go
@@ -127,6 +127,10 @@ func (l *slogHandler) WithGroup(name string) slog.Handler {
 	if l.sink == nil {
 		return l
 	}
+	if name == "" {
+		// slog says to inline empty groups
+		return l
+	}
 	copy := *l
 	if l.slogSink != nil {
 		copy.slogSink = l.slogSink.WithGroup(name)


### PR DESCRIPTION
This is part of a larger cleanup, but is a distinct bugfix.