### PR TITLE
slogr: fix unintended API break in v0.8.0

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Add GOBIN to PATH
         run: echo "PATH=$(go env GOPATH)/bin:$PATH" >>$GITHUB_ENV
       - name: Install dependencies

--- a/slogr/slogr.go
+++ b/slogr/slogr.go
@@ -40,6 +40,13 @@ func NewLogr(handler slog.Handler) logr.Logger {
 	return logr.FromSlogHandler(handler)
 }
 
+// NewSlogHandler returns a slog.Handler which writes to the same sink as the logr.Logger.
+//
+// Deprecated: use [logr.ToSlogHandler] instead.
+func NewSlogHandler(logger logr.Logger) slog.Handler {
+	return logr.ToSlogHandler(logger)
+}
+
 // ToSlogHandler returns a slog.Handler which writes to the same sink as the logr.Logger.
 //
 // Deprecated: use [logr.ToSlogHandler] instead.


### PR DESCRIPTION
logr v0.7.0 had slogr.NewSlogHandler. We must keep that function for API
compatibility. https://github.com/go-logr/logr/pull/237/files#r1434203442
accidentally renamed it.
