### PR TITLE
Fix slog tests for 1.25

### DIFF
--- a/slogr_test.go
+++ b/slogr_test.go
@@ -128,6 +128,7 @@ func TestRunSlogTestsOnSlogHandlerLogSink(t *testing.T) {
 		"a Handler should handle multiple WithGroup and WithAttr calls",
 		"a Handler should not output groups for an empty Record",
 		"a Handler should not output groups if there are no attributes",
+		"a Handler should not output nested groups if there are no attributes",
 		"a Handler should call Resolve on attribute values in groups",
 		"a Handler should call Resolve on attribute values in groups from WithAttrs",
 	}


### PR DESCRIPTION
A new group-related case was added,
much like in commit a6645b7dad5eed81799bbd0a78130d750d9b23b3.

fixes #360