### PR TITLE
Pass `FromContext(...)` context to slog handler

### DIFF
--- a/context_slog.go
+++ b/context_slog.go
@@ -35,7 +35,7 @@ func FromContext(ctx context.Context) (Logger, error) {
 	case Logger:
 		return v, nil
 	case *slog.Logger:
-		return FromSlogHandler(v.Handler()), nil
+		return FromSlogHandlerWithContext(ctx, v.Handler()), nil
 	default:
 		// Not reached.
 		panic(fmt.Sprintf("unexpected value type for logr context key: %T", v))

--- a/context_slog_test.go
+++ b/context_slog_test.go
@@ -63,3 +63,36 @@ func TestContextWithSlog(t *testing.T) {
 
 	// ...read as logr is covered in the non-slog test
 }
+
+func TestContextWithSlogPassesContextToHandler(t *testing.T) {
+	type ctxKey struct{}
+
+	handler := &contextCaptureSlogHandler{Handler: slog.NewJSONHandler(os.Stderr, nil)}
+	ctx := NewContextWithSlogLogger(context.Background(), slog.New(handler))
+
+	ctx = context.WithValue(ctx, ctxKey{}, "value")
+	logger, err := FromContext(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logger.Info("hello")
+
+	if handler.ctx != ctx {
+		t.Fatalf("expected slog handler to get original context")
+	}
+
+	if v := handler.ctx.Value(ctxKey{}); v != "value" {
+		t.Fatalf("expected context value to be preserved, got %#v", v)
+	}
+}
+
+type contextCaptureSlogHandler struct {
+	slog.Handler
+	ctx context.Context
+}
+
+func (h *contextCaptureSlogHandler) Handle(ctx context.Context, record slog.Record) error {
+	h.ctx = ctx
+	return h.Handler.Handle(ctx, record)
+}

--- a/slogr.go
+++ b/slogr.go
@@ -28,7 +28,8 @@ import (
 // The logr verbosity level is mapped to slog levels such that V(0) becomes
 // slog.LevelInfo and V(4) becomes slog.LevelDebug.
 //
-// Deprecated: use [logr.FromSlogHandlerWithContext] instead.
+// When you need a short-lived Logger linked to the current context, consider
+// using FromSlogHandlerWithContext instead and pass the context to it.
 func FromSlogHandler(handler slog.Handler) Logger {
 	return FromSlogHandlerWithContext(context.Background(), handler)
 }
@@ -39,7 +40,9 @@ func FromSlogHandler(handler slog.Handler) Logger {
 // slog.LevelInfo and V(4) becomes slog.LevelDebug.
 //
 // The provided context is passed to the slog.Handler when logging. This allows
-// the slog.Handler to use the context.
+// the slog.Handler to use the context. This should only be used for short-lived
+// Loggers that do not outlive the context. If you need a long-lived Logger, use
+// FromSlogHandler instead.
 func FromSlogHandlerWithContext(ctx context.Context, handler slog.Handler) Logger {
 	if handler, ok := handler.(*slogHandler); ok {
 		if handler.sink == nil {

--- a/slogr.go
+++ b/slogr.go
@@ -27,14 +27,27 @@ import (
 //
 // The logr verbosity level is mapped to slog levels such that V(0) becomes
 // slog.LevelInfo and V(4) becomes slog.LevelDebug.
+//
+// Deprecated: use [logr.FromSlogHandlerWithContext] instead.
 func FromSlogHandler(handler slog.Handler) Logger {
+	return FromSlogHandlerWithContext(context.Background(), handler)
+}
+
+// FromSlogHandlerWithContext returns a Logger which writes to the slog.Handler.
+//
+// The logr verbosity level is mapped to slog levels such that V(0) becomes
+// slog.LevelInfo and V(4) becomes slog.LevelDebug.
+//
+// The provided context is passed to the slog.Handler when logging. This allows
+// the slog.Handler to use the context.
+func FromSlogHandlerWithContext(ctx context.Context, handler slog.Handler) Logger {
 	if handler, ok := handler.(*slogHandler); ok {
 		if handler.sink == nil {
 			return Discard()
 		}
 		return New(handler.sink).V(int(handler.levelBias))
 	}
-	return New(&slogSink{handler: handler})
+	return New(&slogSink{handler: handler, ctx: ctx})
 }
 
 // ToSlogHandler returns a slog.Handler which writes to the same sink as the Logger.

--- a/slogsink.go
+++ b/slogsink.go
@@ -49,6 +49,7 @@ type slogSink struct {
 	callDepth int
 	name      string
 	handler   slog.Handler
+	ctx       context.Context
 }
 
 func (l *slogSink) Init(info RuntimeInfo) {
@@ -66,7 +67,7 @@ func (l *slogSink) WithCallDepth(depth int) LogSink {
 }
 
 func (l *slogSink) Enabled(level int) bool {
-	return l.handler.Enabled(context.Background(), slog.Level(-level))
+	return l.handler.Enabled(l.ctx, slog.Level(-level))
 }
 
 func (l *slogSink) Info(level int, msg string, kvList ...interface{}) {
@@ -90,7 +91,7 @@ func (l *slogSink) log(err error, msg string, level slog.Level, kvList ...interf
 		record.AddAttrs(slog.Any(errKey, err))
 	}
 	record.Add(kvList...)
-	_ = l.handler.Handle(context.Background(), record)
+	_ = l.handler.Handle(l.ctx, record)
 }
 
 func (l slogSink) WithName(name string) LogSink {


### PR DESCRIPTION
Instead of passing `context.Background()`, we now pass the context passed to `FromContext(...)` to the slog `.Handle(...)` function instead.

This is an alternative solution to the problem presented in https://github.com/go-logr/logr/pull/158 (only solves the use case where an slog backend is used).

cc @pohly 