### PR TITLE
CI: avoid floating dependencies, fix issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "_tools"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Add GOBIN to PATH
         run: echo "PATH=$(go env GOPATH)/bin:$PATH" >>$GITHUB_ENV
       - name: Install dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,15 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          #
+          # We are not using "latest" because it was a source of random CI
+          # failures when new checks were added. It should also provide some
+          # protection against supply-chain attacks because "the tags of
+          # golangci-lint cannot be updated, removed: we have a tag protection"
+          # (Ludovic Fernandez, golangci-lint maintainer).
+          #
+          # Would be nice to get it auto-updated via dependabot, though :-/
+          version: v2.11.4
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/_tools/apidiff.sh
+++ b/_tools/apidiff.sh
@@ -65,9 +65,9 @@ fi
 
 if ! which apidiff > /dev/null; then
   echo "Installing golang.org/x/exp/cmd/apidiff"
-  pushd "${TMPDIR:-/tmp}" > /dev/null
-    GO111MODULE=off go get golang.org/x/exp/cmd/apidiff
-  popd > /dev/null
+  # Version is locked in the _tools module and updated there
+  # by dependabot via PRs. This avoids a floating dependency.
+  (cd _tools && go install golang.org/x/exp/cmd/apidiff)
 fi
 
 output=$(mktemp -d -t "apidiff.output.XXXX")

--- a/_tools/go.mod
+++ b/_tools/go.mod
@@ -1,0 +1,12 @@
+module go-logr/logr/_tools
+
+go 1.25.2
+
+tool golang.org/x/exp/cmd/apidiff
+
+require (
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
+	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/tools v0.44.0 // indirect
+)

--- a/_tools/go.sum
+++ b/_tools/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=

--- a/funcr/funcr_test.go
+++ b/funcr/funcr_test.go
@@ -109,18 +109,26 @@ type TjsontagsString struct {
 	String0 string `json:"-"`                 // first field ignored
 	String1 string `json:"string1"`           // renamed
 	String2 string `json:"-"`                 // ignored
+	// "'_'" is what staticcheck suggests:
+	// should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
+	// However, json.Marshal then uses "String3" as name, so this is a wrong suggestion?!
+	//
+	//nolint:staticcheck
 	String3 string `json:"-,"`                // named "-"
 	String4 string `json:"string4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	String5 string `json:","`                 // no-op
 	String6 string `json:",omitempty"`        // ignore if empty
 }
 
 type TjsontagsBool struct {
-	Bool0 bool `json:"-"`               // first field ignored
-	Bool1 bool `json:"bool1"`           // renamed
-	Bool2 bool `json:"-"`               // ignored
+	Bool0 bool `json:"-"`     // first field ignored
+	Bool1 bool `json:"bool1"` // renamed
+	Bool2 bool `json:"-"`     // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Bool3 bool `json:"-,"`              // named "-"
 	Bool4 bool `json:"bool4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Bool5 bool `json:","`               // no-op
 	Bool6 bool `json:",omitempty"`      // ignore if empty
 }
@@ -129,8 +137,10 @@ type TjsontagsInt struct {
 	Int0 int `json:"-"`              // first field ignored
 	Int1 int `json:"int1"`           // renamed
 	Int2 int `json:"-"`              // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Int3 int `json:"-,"`             // named "-"
 	Int4 int `json:"int4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Int5 int `json:","`              // no-op
 	Int6 int `json:",omitempty"`     // ignore if empty
 }
@@ -139,8 +149,10 @@ type TjsontagsUint struct {
 	Uint0 int  `json:"-"`               // first field ignored
 	Uint1 uint `json:"uint1"`           // renamed
 	Uint2 uint `json:"-"`               // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Uint3 uint `json:"-,"`              // named "-"
 	Uint4 uint `json:"uint4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Uint5 uint `json:","`               // no-op
 	Uint6 uint `json:",omitempty"`      // ignore if empty
 }
@@ -149,8 +161,10 @@ type TjsontagsFloat struct {
 	Float0 float64 `json:"-"`                // first field ignored
 	Float1 float64 `json:"float1"`           // renamed
 	Float2 float64 `json:"-"`                // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Float3 float64 `json:"-,"`               // named "-"
 	Float4 float64 `json:"float4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Float5 float64 `json:","`                // no-op
 	Float6 float64 `json:",omitempty"`       // ignore if empty
 }
@@ -159,8 +173,10 @@ type TjsontagsComplex struct {
 	Complex0 complex128 `json:"-"`                  // first field ignored
 	Complex1 complex128 `json:"complex1"`           // renamed
 	Complex2 complex128 `json:"-"`                  // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Complex3 complex128 `json:"-,"`                 // named "-"
 	Complex4 complex128 `json:"complex4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Complex5 complex128 `json:","`                  // no-op
 	Complex6 complex128 `json:",omitempty"`         // ignore if empty
 }
@@ -169,8 +185,10 @@ type TjsontagsPtr struct {
 	Ptr0 *string `json:"-"`              // first field ignored
 	Ptr1 *string `json:"ptr1"`           // renamed
 	Ptr2 *string `json:"-"`              // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Ptr3 *string `json:"-,"`             // named "-"
 	Ptr4 *string `json:"ptr4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Ptr5 *string `json:","`              // no-op
 	Ptr6 *string `json:",omitempty"`     // ignore if empty
 }
@@ -179,8 +197,10 @@ type TjsontagsArray struct {
 	Array0 [2]string `json:"-"`                // first field ignored
 	Array1 [2]string `json:"array1"`           // renamed
 	Array2 [2]string `json:"-"`                // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Array3 [2]string `json:"-,"`               // named "-"
 	Array4 [2]string `json:"array4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Array5 [2]string `json:","`                // no-op
 	Array6 [2]string `json:",omitempty"`       // ignore if empty
 }
@@ -189,8 +209,10 @@ type TjsontagsSlice struct {
 	Slice0 []string `json:"-"`                // first field ignored
 	Slice1 []string `json:"slice1"`           // renamed
 	Slice2 []string `json:"-"`                // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Slice3 []string `json:"-,"`               // named "-"
 	Slice4 []string `json:"slice4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Slice5 []string `json:","`                // no-op
 	Slice6 []string `json:",omitempty"`       // ignore if empty
 }
@@ -199,8 +221,10 @@ type TjsontagsMap struct {
 	Map0 map[string]string `json:"-"`              // first field ignored
 	Map1 map[string]string `json:"map1"`           // renamed
 	Map2 map[string]string `json:"-"`              // ignored
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Map3 map[string]string `json:"-,"`             // named "-"
 	Map4 map[string]string `json:"map4,omitempty"` // renamed, ignore if empty
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Map5 map[string]string `json:","`              // no-op
 	Map6 map[string]string `json:",omitempty"`     // ignore if empty
 }
@@ -234,8 +258,10 @@ type Tembedjsontags struct {
 	Outer   string
 	Tinner1 `json:"inner1"`
 	Tinner2 `json:"-"`
+	//nolint:staticcheck  // SA5008: should encoding/json ignore this field or name it "-"? Either use `json:"-"` to ignore the field or use `json:"'-',"` to specify "-" as the name
 	Tinner3 `json:"-,"`
 	Tinner4 `json:"inner4,omitempty"`
+	//nolint:staticcheck // SA5008: malformed `json` tag: invalid trailing ',' character
 	Tinner5 `json:","`
 	Tinner6 `json:"inner6,omitempty"`
 }


### PR DESCRIPTION
The usage of apidiff@latest breaks from time to time, most recently because it requires Go 1.25 instead of the 1.24 configured in the GitHub action. By locking to a specific version we avoid that and a potential supply-chain attack.

Dependabot gets configured to update the version of apidiff. If that PR fails, we need to fix it up manually before merging.

Similar for golangci-lint: new checks can fail and we don't know what "latest" is. Unfortunately that version cannot be bumped by dependabot. It's said to be possible via "renovate", but configuring that seems overkill.