### PR TITLE
funcr: bound slog.Group nesting depth to prevent stack overflow

### DIFF
--- a/funcr/slogsink.go
+++ b/funcr/slogsink.go
@@ -32,7 +32,7 @@ const extraSlogSinkDepth = 3 // 2 for slog, 1 for SlogSink
 func (l fnlogger) Handle(_ context.Context, record slog.Record) error {
 	kvList := make([]any, 0, 2*record.NumAttrs())
 	record.Attrs(func(attr slog.Attr) bool {
-		kvList = attrToKVs(attr, kvList)
+		kvList = attrToKVs(attr, kvList, l.opts.MaxLogDepth)
 		return true
 	})
 
@@ -48,7 +48,7 @@ func (l fnlogger) Handle(_ context.Context, record slog.Record) error {
 func (l fnlogger) WithAttrs(attrs []slog.Attr) logr.SlogSink {
 	kvList := make([]any, 0, 2*len(attrs))
 	for _, attr := range attrs {
-		kvList = attrToKVs(attr, kvList)
+		kvList = attrToKVs(attr, kvList, l.opts.MaxLogDepth)
 	}
 	l.AddValues(kvList)
 	return &l
@@ -60,14 +60,25 @@ func (l fnlogger) WithGroup(name string) logr.SlogSink {
 }
 
 // attrToKVs appends a slog.Attr to a logr-style kvList.  It handle slog Groups
-// and other details of slog.
-func attrToKVs(attr slog.Attr, kvList []any) []any {
+// and other details of slog.  maxDepth bounds recursion into nested groups so a
+// deeply-nested slog.Group cannot exhaust the stack; it is decremented per group
+// level and starts at the Formatter's MaxLogDepth (past which the formatter would
+// truncate the rendering anyway).
+func attrToKVs(attr slog.Attr, kvList []any, maxDepth int) []any {
 	attrVal := attr.Value.Resolve()
 	if attrVal.Kind() == slog.KindGroup {
+		if maxDepth <= 0 {
+			// Nesting is too deep to build without risking a stack overflow.
+			// Stop here; the formatter truncates below MaxLogDepth regardless.
+			if attr.Key != "" {
+				kvList = append(kvList, attr.Key, "<max-log-depth-exceeded>")
+			}
+			return kvList
+		}
 		groupVal := attrVal.Group()
 		grpKVs := make([]any, 0, 2*len(groupVal))
 		for _, attr := range groupVal {
-			grpKVs = attrToKVs(attr, grpKVs)
+			grpKVs = attrToKVs(attr, grpKVs, maxDepth-1)
 		}
 		if attr.Key == "" {
 			// slog says we have to inline these

--- a/funcr/slogsink_test.go
+++ b/funcr/slogsink_test.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -229,5 +230,25 @@ func TestLogrSlogConversion(t *testing.T) {
 	if want, got := f, f2; got != want {
 		t.Helper()
 		t.Errorf("Expected %T %+v, got instead: %T %+v", want, want, got, got)
+	}
+}
+
+func TestSlogSinkGroupMaxDepth(t *testing.T) {
+	// A deeply-nested slog.Group must not recurse without bound while building
+	// the kvList — that would eventually overflow the goroutine stack (a fatal,
+	// unrecoverable crash). attrToKVs stops at MaxLogDepth and emits a truncation
+	// marker, matching how the formatter truncates deep nesting when rendering.
+	var attr slog.Attr = slog.Int("leaf", 1)
+	for i := 0; i < 1000; i++ { // far deeper than the default MaxLogDepth
+		attr = slog.Group("g", attr)
+	}
+
+	capt := &capture{}
+	logger := logr.New(newSink(capt.Func, NewFormatterJSON(Options{})))
+	slogger := slog.New(logr.ToSlogHandler(logger))
+	slogger.Info("msg", attr)
+
+	if !strings.Contains(capt.log, "<max-log-depth-exceeded>") {
+		t.Errorf("expected deep group nesting to be truncated, got: %s", capt.log)
 	}
 }


### PR DESCRIPTION
Follow-up to the recursive-values work in #446. That PR handles the pointer/interface case in `prettyWithFlags`; this is a **separate** unbounded recursion in the same package, on a different axis.

`attrToKVs` in `slogsink.go` recurses once per nested `slog.KindGroup` with no depth limit:

```go
func attrToKVs(attr slog.Attr, kvList []any) []any {
	attrVal := attr.Value.Resolve()
	if attrVal.Kind() == slog.KindGroup {
		groupVal := attrVal.Group()
		grpKVs := make([]any, 0, 2*len(groupVal))
		for _, attr := range groupVal {
			grpKVs = attrToKVs(attr, grpKVs)   // no depth guard
		}
		...
```

A sufficiently deeply-nested `slog.Group` (attacker- or bug-produced structured data logged through the `SlogSink`) overflows the goroutine stack while building the kvList — a fatal, unrecoverable crash. Because it happens during construction, it overflows *before* the formatter’s `MaxLogDepth` check ever runs, so `MaxLogDepth` alone does not protect against it. It is not a cycle, so the `ptrDepth`/`ptrMap` machinery in #446 does not cover it either.

**Fix:** thread a `maxDepth` budget (starting at the Formatter’s `MaxLogDepth`) through `attrToKVs`, decremented per group level; past it, stop recursing and emit the same `"<max-log-depth-exceeded>"` marker the formatter uses. No behavior change for normal nesting (the formatter truncates below `MaxLogDepth` anyway). Added a regression test; `go test ./...` (incl. the slogtest conformance suite) passes, `go vet`/`gofmt` clean.

Happy to adjust the limit or the marker to taste.