### PR TITLE
fix: FromSlogHandler(nil) returns Discard logger

### DIFF
--- a/slogr.go
+++ b/slogr.go
@@ -28,6 +28,9 @@ import (
 // The logr verbosity level is mapped to slog levels such that V(0) becomes
 // slog.LevelInfo and V(4) becomes slog.LevelDebug.
 func FromSlogHandler(handler slog.Handler) Logger {
+	if handler == nil {
+		return Discard()
+	}
 	if handler, ok := handler.(*slogHandler); ok {
 		if handler.sink == nil {
 			return Discard()

--- a/slogr_test.go
+++ b/slogr_test.go
@@ -196,3 +196,13 @@ func expectEqual(t *testing.T, expected, actual any) {
 		t.Errorf("Expected %T %+v, got instead: %T %+v", expected, expected, actual, actual)
 	}
 }
+
+func TestFromSlogHandlerNil(t *testing.T) {
+	log := FromSlogHandler(nil)
+	if log.GetSink() != nil {
+		t.Fatalf("expected discard logger with nil sink, got %#v", log.GetSink())
+	}
+	// Must not panic.
+	log.Info("ignored")
+	log.Error(nil, "ignored")
+}


### PR DESCRIPTION
## Summary
`New(nil)` is documented to produce a discard logger. `FromSlogHandler(nil)` instead wrapped a nil `slog.Handler` and panicked on the first log call.

Treat a nil handler like a nil sink and return `Discard()`.

## Test plan
- [x] `go test ./...`
- [x] Unit test covering `FromSlogHandler(nil)`